### PR TITLE
Fix AAP project repo URL to point to correct fork

### DIFF
--- a/ansible/pb_setup_aap.yml
+++ b/ansible/pb_setup_aap.yml
@@ -47,7 +47,7 @@
   vars:
     aap_org_name: "SummitCollection"
     controller_api_base: "{{ lookup('env', 'AAP_URL') }}/api/controller"
-    github_repo: "https://github.com/my0373/summit-netbox-circuits-demo"
+    github_repo: "https://github.com/leogallego/summit-netbox-circuits-demo"
     github_branch: "main"
     de_image: "registry.redhat.io/ansible-automation-platform-26/de-supported-rhel9:latest"
     eda_stream_token: "{{ lookup('env', 'EDA_STREAM_TOKEN') }}"


### PR DESCRIPTION
## Summary
- Changed `github_repo` in `pb_setup_aap.yml` from `my0373/summit-netbox-circuits-demo` (upstream) to `leogallego/summit-netbox-circuits-demo` (our fork)
- This fixes both Controller and EDA projects syncing the wrong rulebook, which launched "Circuit Failover Workflow" instead of "SummitCollection Circuit Failover Workflow"

## Test plan
- [ ] Run `./run-playbook.sh ansible/pb_setup_aap.yml` to update AAP projects
- [ ] Verify EDA project syncs the correct rulebook with SummitCollection workflow name
- [ ] Trigger circuit offline and confirm correct workflow launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)