### PR TITLE
Make container registry credential conditional

### DIFF
--- a/ansible/pb_setup_aap.yml
+++ b/ansible/pb_setup_aap.yml
@@ -174,9 +174,10 @@
         credential_type: "Container Registry"
         inputs:
           host: "{{ lookup('env', 'REGISTRY_HOST') | default('quay.io', true) }}"
-          username: "{{ lookup('env', 'REGISTRY_USERNAME') | default(omit, true) }}"
-          password: "{{ lookup('env', 'REGISTRY_PASSWORD') | default(omit, true) }}"
+          username: "{{ lookup('env', 'REGISTRY_USERNAME') }}"
+          password: "{{ lookup('env', 'REGISTRY_PASSWORD') }}"
         state: present
+      when: lookup('env', 'REGISTRY_USERNAME') | length > 0
       tags:
         - credentials
 
@@ -241,7 +242,7 @@
         name: "{{ ee_name }}"
         image: "{{ ee_image }}"
         organization: "{{ aap_org_name }}"
-        credential: "{{ registry_cred_name }}"
+        credential: "{{ registry_cred_name if lookup('env', 'REGISTRY_USERNAME') | length > 0 else omit }}"
         pull: missing
         state: present
       tags:


### PR DESCRIPTION
## Summary
- Skip creating Container Registry credential when `REGISTRY_USERNAME` is empty
- Don't attach credential to the EE when no registry creds — allows AAP to pull public images without auth
- Fixes `RuntimeError: Please recheck that your host, username, and password fields are all filled` when running jobs with a public EE image

## Test plan
- [ ] Run `./run-playbook.sh ansible/pb_setup_aap.yml --tags ee` with empty `REGISTRY_USERNAME` — EE should be created without credential
- [ ] Launch a job template — should pull the public EE image successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)