### PR TITLE
Deploy failover report to GitHub Pages (issue #26)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,23 +28,24 @@ RH_REGISTRY_PASSWORD=
 AH_URL=https://console.redhat.com/api/automation-hub/
 AH_TOKEN=your_automation_hub_token_here
 
-# Infrastructure (optional — populated by setup_infra.sh after Terraform)
-# Leave empty to skip report publishing and router registration.
+# Report publishing — GitHub Pages (optional — leave empty to skip)
+# Token needs contents:write scope on the target repo.
+REPORT_FILENAME=failover_report_collection.html
+GITHUB_TOKEN=
+GITHUB_REPO=leogallego/summit-netbox-circuits-demo
+GITHUB_REPORT_DIR=docs
+
+# Report publishing — SSH server (optional — leave empty to skip)
+# Populated by setup_infra.sh after Terraform, or set manually.
 REPORT_SERVER_HOST=
 REPORT_SERVER_PORT=2222
 REPORT_URL=
+PRIVATE_KEY_PATH=
+
+# Router (optional — populated by setup_infra.sh after Terraform)
+# Leave empty to skip router registration.
 ROUTER_IP=
 ROUTER_PASSWORD=
 ROUTER_USERNAME=iosuser
 ROUTER_PRIMARY_GW=172.16.0.1
 ROUTER_BACKUP_GW=172.16.1.1
-PRIVATE_KEY_PATH=
-
-# Report settings
-REPORT_FILENAME=failover_report_collection.html
-
-# GitHub Pages report publishing (optional — leave empty to skip)
-# Token needs contents:write scope on the target repo.
-GITHUB_TOKEN=
-GITHUB_REPO=leogallego/summit-netbox-circuits-demo
-GITHUB_REPORT_DIR=docs

--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,12 @@ ROUTER_USERNAME=iosuser
 ROUTER_PRIMARY_GW=172.16.0.1
 ROUTER_BACKUP_GW=172.16.1.1
 PRIVATE_KEY_PATH=
+
+# Report settings
+REPORT_FILENAME=failover_report_collection.html
+
+# GitHub Pages report publishing (optional — leave empty to skip)
+# Token needs contents:write scope on the target repo.
+GITHUB_TOKEN=
+GITHUB_REPO=leogallego/summit-netbox-circuits-demo
+GITHUB_REPORT_DIR=docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ NetBox Copilot → PATCH circuit to offline
   → EDA rulebook evaluates condition → launches workflow on Automation Controller
   → AAP "Circuit Failover Workflow":
       Step 1: pb_circuit_failover.yml (query NetBox via nb_lookup, discover backup, push router config, update NetBox via netbox_circuit)
-      Step 2: pb_deploy_report.yml (re-query state, render Jinja2 HTML report, deploy to report server via SSH)
+      Step 2: pb_deploy_report.yml (re-query state, render Jinja2 HTML report, publish to GitHub Pages and/or deploy to report server via SSH)
   → Visual Explorer updates live, report served on HTTPS
 ```
 
@@ -55,6 +55,8 @@ uv run --with Pillow --with python-pptx python slides/make_deck.py
 
 All secrets and infrastructure variables live in `.env` (gitignored). Playbooks read credentials via `ansible/vars/netbox_creds.yml` and `lookup('env', ...)` — either source `.env` locally or rely on AAP credential injection (NetBox credential type injects `NETBOX_API` + `NETBOX_TOKEN`).
 
+Report settings and GitHub Pages credentials are in `ansible/vars/report.yml` — imported via `vars_files:` in `pb_deploy_report.yml`. GitHub credential type in AAP injects `GITHUB_TOKEN`, `GITHUB_REPO`, `GITHUB_REPORT_DIR` as env vars.
+
 Infrastructure variables (`REPORT_SERVER_HOST`, `ROUTER_IP`, etc.) are written to `.env` by `setup_infra.sh` from Terraform outputs, or set manually.
 
 ## Key Design Decisions
@@ -63,6 +65,7 @@ Infrastructure variables (`REPORT_SERVER_HOST`, `ROUTER_IP`, etc.) are written t
 - **netbox.netbox collection**: All NetBox interactions use `nb_lookup` (reads) and `netbox_circuit` (status updates). No raw `ansible.builtin.uri` API calls.
 - **Simulated router operations**: Router config pushes are `debug` tasks, not real device interactions. The demo has no actual network devices.
 - **Report server**: EC2 instance provisioned by Terraform, nginx with HTTPS, SSH on port 2222.
+- **GitHub Pages as default report target**: The HTML failover report is published to the repo's `docs/` directory via the GitHub Contents API (`ansible.builtin.uri`). GitHub Pages serves it from the `main` branch `/docs` path. The SSH/EC2 report server is kept as a conditional fallback.
 - **NetBox circuit tag `dd`**: All demo-relevant circuits are tagged `dd` in NetBox. This tag scopes all queries — backup discovery, reset, and report generation only touch `dd`-tagged circuits.
 - **NetBox v4.5 token compatibility**: v2 tokens (default on NetBox 4.5+) work with pynetbox >= 7.6.0. The `network-netbox-eda-ee` EE ships pynetbox 7.6.1. Pass the full `nbt_<key>.<token>` format.
 - **Webhook body template**: Use empty body_template (NetBox default payload). Custom templates with `{{ data | tojson }}` fail on NetBox v4.5.

--- a/ansible/pb_deploy_report.yml
+++ b/ansible/pb_deploy_report.yml
@@ -21,10 +21,10 @@
 
   vars_files:
     - vars/netbox_creds.yml
+    - vars/report.yml
 
   vars:
     failed_circuit: "IPLC-GB-AT-PRI"
-    report_filename: "failover_report_collection.html"
     report_dir: "{{ playbook_dir }}/reports"
 
   tasks:
@@ -177,17 +177,100 @@
         msg: "Report generated: {{ report_dir }}/{{ report_filename }}"
         verbosity: 0
 
-# ── Play 2: Register report server (if configured) ────────────────────────────
+# ── Play 2: Publish report to GitHub Pages (if configured) ──────────────────
+
+- name: Publish failover report to GitHub Pages
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars_files:
+    - vars/report.yml
+
+  vars:
+    report_dir: "{{ playbook_dir }}/reports"
+
+  tasks:
+    - name: Skip if no GitHub token configured
+      ansible.builtin.meta: end_play
+      when: github_token | length == 0
+
+    - name: Read generated report file
+      ansible.builtin.slurp:
+        src: "{{ report_dir }}/{{ report_filename }}"
+      register: report_content
+
+    - name: Check if report already exists on GitHub
+      ansible.builtin.uri:
+        url: "https://api.github.com/repos/{{ github_repo }}/contents/{{ github_report_dir }}/{{ report_filename }}"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ github_token }}"
+          Accept: "application/vnd.github.v3+json"
+        status_code:
+          - 200
+          - 404
+      register: github_existing_file
+
+    - name: Set file SHA for update
+      ansible.builtin.set_fact:
+        github_file_sha: "{{ github_existing_file.json.sha | default('') }}"
+      when: github_existing_file.status == 200
+
+    - name: Set empty SHA for first deploy
+      ansible.builtin.set_fact:
+        github_file_sha: ""
+      when: github_existing_file.status == 404
+
+    - name: Build request body for GitHub Contents API
+      ansible.builtin.set_fact:
+        github_put_body: >-
+          {{
+            {
+              'message': 'Update failover report',
+              'content': report_content.content
+            }
+            | combine(
+                {'sha': github_file_sha}
+                if github_file_sha | length > 0
+                else {}
+              )
+          }}
+
+    - name: Push report to GitHub repository
+      ansible.builtin.uri:
+        url: "https://api.github.com/repos/{{ github_repo }}/contents/{{ github_report_dir }}/{{ report_filename }}"
+        method: PUT
+        headers:
+          Authorization: "Bearer {{ github_token }}"
+          Accept: "application/vnd.github.v3+json"
+        body_format: json
+        body: "{{ github_put_body }}"
+        status_code:
+          - 200
+          - 201
+      register: github_push_result
+
+    - name: Report published to GitHub Pages
+      ansible.builtin.debug:
+        msg: >-
+          Report published to GitHub Pages:
+          https://{{ github_repo | regex_replace('/', '.github.io/') }}/{{ report_filename }}
+        verbosity: 0
+
+# ── Play 3: Register report server (if configured) ────────────────────────────
 
 - name: Register report server for publishing
   hosts: localhost
   gather_facts: false
 
+  vars_files:
+    - vars/report.yml
+
   vars:
     report_server_host: "{{ lookup('env', 'REPORT_SERVER_HOST') }}"
     report_server_port: "{{ lookup('env', 'REPORT_SERVER_PORT') | default('2222', true) }}"
     report_url: "{{ lookup('env', 'REPORT_URL') }}"
-    report_filename: "failover_report_collection.html"
 
   tasks:
     - name: Skip if no report server configured
@@ -203,7 +286,7 @@
         report_filename: "{{ report_filename }}"
         report_url: "{{ report_url | default('https://' + report_server_host + '/' + report_filename, true) }}"
 
-# ── Play 3: Publish report to web server ──────────────────────────────────────
+# ── Play 4: Publish report to web server ──────────────────────────────────────
 
 - name: Publish failover report to web server
   hosts: report_servers

--- a/ansible/pb_setup_aap.yml
+++ b/ansible/pb_setup_aap.yml
@@ -90,6 +90,11 @@
     eda_activation_name: "{{ aap_org_name }} EDA Circuit Failover"
     # Report
     report_filename: "failover_report_collection.html"
+    # GitHub Pages
+    github_token: "{{ lookup('env', 'GITHUB_TOKEN') | default('', true) }}"
+    github_repo: "{{ lookup('env', 'GITHUB_REPO') | default('leogallego/summit-netbox-circuits-demo', true) }}"
+    github_report_dir: "{{ lookup('env', 'GITHUB_REPORT_DIR') | default('docs', true) }}"
+    github_cred_name: "{{ aap_org_name }} GitHub"
     # NetBox resource names
     netbox_webhook_name: "{{ aap_org_name }} AAP Circuit Failover"
 
@@ -162,6 +167,53 @@
           NETBOX_API: "{{ netbox_url }}"
           NETBOX_TOKEN: "{{ netbox_token }}"
         state: present
+      tags:
+        - credentials
+
+    # ── Controller: GitHub credential type ──────────────────────────────────
+
+    - name: Create GitHub credential type
+      ansible.controller.credential_type:
+        name: "GitHub"
+        kind: cloud
+        inputs:
+          fields:
+            - id: GITHUB_TOKEN
+              type: string
+              label: "Personal Access Token"
+              secret: true
+            - id: GITHUB_REPO
+              type: string
+              label: "Repository (owner/name)"
+            - id: GITHUB_REPORT_DIR
+              type: string
+              label: "Report directory in repo"
+          required:
+            - GITHUB_TOKEN
+            - GITHUB_REPO
+        injectors:
+          env:
+            GITHUB_TOKEN: "{{ '{{' }} GITHUB_TOKEN {{ '}}' }}"
+            GITHUB_REPO: "{{ '{{' }} GITHUB_REPO {{ '}}' }}"
+            GITHUB_REPORT_DIR: "{{ '{{' }} GITHUB_REPORT_DIR {{ '}}' }}"
+        state: present
+      when: github_token | length > 0
+      tags:
+        - credentials
+
+    # ── Controller: GitHub credential ─────────────────────────────────────────
+
+    - name: Create GitHub credential
+      ansible.controller.credential:
+        name: "{{ github_cred_name }}"
+        organization: "{{ aap_org_name }}"
+        credential_type: "GitHub"
+        inputs:
+          GITHUB_TOKEN: "{{ github_token }}"
+          GITHUB_REPO: "{{ github_repo }}"
+          GITHUB_REPORT_DIR: "{{ github_report_dir }}"
+        state: present
+      when: github_token | length > 0
       tags:
         - credentials
 
@@ -285,11 +337,14 @@
         ask_variables_on_launch: true
         extra_vars:
           failed_circuit: "IPLC-GB-PH-PRI"
-        credentials:
-          - "{{ netbox_cred_name }}"
+        credentials: >-
+          {{
+            [netbox_cred_name]
+            + ([github_cred_name] if github_token | length > 0 else [])
+          }}
         description: >-
-          Generates and deploys the HTML failover report
-          to the report web server.
+          Generates and deploys the HTML failover report.
+          Publishes to GitHub Pages when GitHub credential is configured.
         state: present
       tags:
         - job_templates
@@ -771,6 +826,7 @@
             Controller Resources:
               Organization:     {{ aap_org_name }}
               NetBox Cred:      {{ netbox_cred_name }}
+              {{ 'GitHub Cred:     ' ~ github_cred_name if github_token | length > 0 else 'GitHub Cred:     (not configured — report published locally only)' }}
               Inventory:        {{ inventory_name }}
               Project:          {{ controller_project_name }}
               JT Failover:      {{ jt_failover_name }}

--- a/ansible/vars/report.yml
+++ b/ansible/vars/report.yml
@@ -1,0 +1,5 @@
+---
+report_filename: "{{ lookup('env', 'REPORT_FILENAME') | default('failover_report_collection.html', true) }}"
+github_token: "{{ lookup('env', 'GITHUB_TOKEN') | default('', true) }}"
+github_repo: "{{ lookup('env', 'GITHUB_REPO') | default('leogallego/summit-netbox-circuits-demo', true) }}"
+github_report_dir: "{{ lookup('env', 'GITHUB_REPORT_DIR') | default('docs', true) }}"

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Circuit Failover Reports</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 640px; margin: 4rem auto; padding: 0 1rem; color: #333; }
+    h1 { font-size: 1.4rem; }
+    p { color: #666; }
+  </style>
+</head>
+<body>
+  <h1>Circuit Failover Reports</h1>
+  <p>No failover report generated yet. Run the Circuit Failover Workflow to publish a report here.</p>
+</body>
+</html>

--- a/docs/superpowers/plans/2026-05-04-github-pages-report.md
+++ b/docs/superpowers/plans/2026-05-04-github-pages-report.md
@@ -1,0 +1,569 @@
+# GitHub Pages Report Deployment — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add GitHub Pages as the default report publishing target, keeping SSH as a conditional fallback.
+
+**Architecture:** A new shared vars file (`ansible/vars/report.yml`) provides a single source of truth for report settings and GitHub credentials. A new Play 2 in `pb_deploy_report.yml` uses `ansible.builtin.slurp` + `ansible.builtin.uri` (GitHub Contents API) to push the generated HTML report to the repo's `docs/` directory. AAP gets a custom "GitHub" credential type that injects env vars for the playbook.
+
+**Tech Stack:** Ansible (ansible.builtin.uri, ansible.builtin.slurp), GitHub Contents API, GitHub Pages, AAP 2.6 credential types
+
+**Spec:** `docs/superpowers/specs/2026-05-04-github-pages-report-design.md`
+
+---
+
+## File Map
+
+| Action | File | Purpose |
+|--------|------|---------|
+| Create | `ansible/vars/report.yml` | Shared vars: report_filename, github_token, github_repo, github_report_dir |
+| Create | `docs/.nojekyll` | Empty file — disables Jekyll on GitHub Pages |
+| Create | `docs/index.html` | Placeholder landing page for GitHub Pages |
+| Modify | `ansible/pb_deploy_report.yml` | Add GitHub Pages publish play (Play 2), import shared vars in all plays |
+| Modify | `ansible/pb_setup_aap.yml` | Add GitHub credential type + credential + conditional JT attachment |
+| Modify | `.env.example` | Add REPORT_FILENAME, GITHUB_TOKEN, GITHUB_REPO, GITHUB_REPORT_DIR |
+| Modify | `CLAUDE.md` | Update architecture diagram and design decisions |
+
+---
+
+### Task 1: Create shared vars file (`ansible/vars/report.yml`)
+
+**Files:**
+- Create: `ansible/vars/report.yml`
+
+- [ ] **Step 1: Create the vars file**
+
+```yaml
+---
+report_filename: "{{ lookup('env', 'REPORT_FILENAME') | default('failover_report_collection.html', true) }}"
+github_token: "{{ lookup('env', 'GITHUB_TOKEN') | default('', true) }}"
+github_repo: "{{ lookup('env', 'GITHUB_REPO') | default('leogallego/summit-netbox-circuits-demo', true) }}"
+github_report_dir: "{{ lookup('env', 'GITHUB_REPORT_DIR') | default('docs', true) }}"
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ansible/vars/report.yml
+git commit -m "feat: add shared report vars file (issue #26)
+
+Single source of truth for report_filename and GitHub Pages
+settings. Each variable reads from its env var with a sensible
+default.
+
+Assisted-by: <model> <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Create GitHub Pages static files
+
+**Files:**
+- Create: `docs/.nojekyll`
+- Create: `docs/index.html`
+
+- [ ] **Step 1: Create `docs/.nojekyll`**
+
+Empty file (zero bytes). This tells GitHub Pages to skip Jekyll processing and serve raw HTML.
+
+- [ ] **Step 2: Create `docs/index.html`**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Circuit Failover Reports</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 640px; margin: 4rem auto; padding: 0 1rem; color: #333; }
+    h1 { font-size: 1.4rem; }
+    p { color: #666; }
+  </style>
+</head>
+<body>
+  <h1>Circuit Failover Reports</h1>
+  <p>No failover report generated yet. Run the Circuit Failover Workflow to publish a report here.</p>
+</body>
+</html>
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/.nojekyll docs/index.html
+git commit -m "feat: add GitHub Pages scaffolding (issue #26)
+
+.nojekyll disables Jekyll processing. index.html is a placeholder
+landing page until a failover report is published.
+
+Assisted-by: <model> <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Update `.env.example` with new variables
+
+**Files:**
+- Modify: `.env.example`
+
+- [ ] **Step 1: Add report and GitHub Pages variables**
+
+Append the following block at the end of `.env.example`, after the existing `PRIVATE_KEY_PATH=` line:
+
+```
+# Report settings
+REPORT_FILENAME=failover_report_collection.html
+
+# GitHub Pages report publishing (optional — leave empty to skip)
+# Token needs contents:write scope on the target repo.
+GITHUB_TOKEN=
+GITHUB_REPO=leogallego/summit-netbox-circuits-demo
+GITHUB_REPORT_DIR=docs
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .env.example
+git commit -m "feat: add GitHub Pages env vars to .env.example (issue #26)
+
+Adds REPORT_FILENAME, GITHUB_TOKEN, GITHUB_REPO, and
+GITHUB_REPORT_DIR with comments explaining each.
+
+Assisted-by: <model> <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Modify `pb_deploy_report.yml` — import shared vars and add GitHub Pages play
+
+This is the main playbook change. The playbook goes from 3 plays to 4 plays:
+
+1. Generate HTML report (existing — modified to use shared vars)
+2. **Publish to GitHub Pages (NEW)**
+3. Register report server (existing — modified to use shared vars)
+4. Publish to web server via SSH (existing — unchanged)
+
+**Files:**
+- Modify: `ansible/pb_deploy_report.yml:17-28` (Play 1 vars)
+- Modify: `ansible/pb_deploy_report.yml:180-204` (Play 2 → Play 3 vars)
+- Insert new Play 2 between current Play 1 and Play 2
+
+- [ ] **Step 1: Update Play 1 — replace hardcoded `report_filename` with shared vars import**
+
+In the first play (line 17–178), make two changes:
+
+1. Add `vars/report.yml` to `vars_files:` (after `vars/netbox_creds.yml`)
+2. Remove `report_filename` from the `vars:` block (keep `failed_circuit` and `report_dir`)
+
+Before:
+```yaml
+  vars_files:
+    - vars/netbox_creds.yml
+
+  vars:
+    failed_circuit: "IPLC-GB-AT-PRI"
+    report_filename: "failover_report_collection.html"
+    report_dir: "{{ playbook_dir }}/reports"
+```
+
+After:
+```yaml
+  vars_files:
+    - vars/netbox_creds.yml
+    - vars/report.yml
+
+  vars:
+    failed_circuit: "IPLC-GB-AT-PRI"
+    report_dir: "{{ playbook_dir }}/reports"
+```
+
+- [ ] **Step 2: Insert new Play 2 — Publish to GitHub Pages**
+
+Insert this entire play between the current Play 1 (ends at line 178) and the current Play 2 (starts at line 180 "Register report server for publishing"). This play is conditional on `github_token` being non-empty.
+
+```yaml
+# ── Play 2: Publish report to GitHub Pages (if configured) ──────────────────
+
+- name: Publish failover report to GitHub Pages
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars_files:
+    - vars/report.yml
+
+  vars:
+    report_dir: "{{ playbook_dir }}/reports"
+
+  tasks:
+    - name: Skip if no GitHub token configured
+      ansible.builtin.meta: end_play
+      when: github_token | length == 0
+
+    - name: Read generated report file
+      ansible.builtin.slurp:
+        src: "{{ report_dir }}/{{ report_filename }}"
+      register: report_content
+
+    - name: Check if report already exists on GitHub
+      ansible.builtin.uri:
+        url: "https://api.github.com/repos/{{ github_repo }}/contents/{{ github_report_dir }}/{{ report_filename }}"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ github_token }}"
+          Accept: "application/vnd.github.v3+json"
+        status_code:
+          - 200
+          - 404
+      register: github_existing_file
+
+    - name: Set file SHA for update
+      ansible.builtin.set_fact:
+        github_file_sha: "{{ github_existing_file.json.sha | default('') }}"
+      when: github_existing_file.status == 200
+
+    - name: Set empty SHA for first deploy
+      ansible.builtin.set_fact:
+        github_file_sha: ""
+      when: github_existing_file.status == 404
+
+    - name: Build request body for GitHub Contents API
+      ansible.builtin.set_fact:
+        github_put_body: >-
+          {{
+            {
+              'message': 'Update failover report',
+              'content': report_content.content
+            }
+            | combine(
+                {'sha': github_file_sha}
+                if github_file_sha | length > 0
+                else {}
+              )
+          }}
+
+    - name: Push report to GitHub repository
+      ansible.builtin.uri:
+        url: "https://api.github.com/repos/{{ github_repo }}/contents/{{ github_report_dir }}/{{ report_filename }}"
+        method: PUT
+        headers:
+          Authorization: "Bearer {{ github_token }}"
+          Accept: "application/vnd.github.v3+json"
+        body_format: json
+        body: "{{ github_put_body }}"
+        status_code:
+          - 200
+          - 201
+      register: github_push_result
+
+    - name: Report published to GitHub Pages
+      ansible.builtin.debug:
+        msg: >-
+          Report published to GitHub Pages:
+          https://{{ github_repo | regex_replace('/', '.github.io/') }}/{{ report_filename }}
+        verbosity: 0
+```
+
+- [ ] **Step 3: Update Play 3 (formerly Play 2) — replace hardcoded `report_filename` with shared vars import**
+
+In the "Register report server for publishing" play (currently line 180), make two changes:
+
+1. Add `vars_files:` with `vars/report.yml`
+2. Remove `report_filename` from the `vars:` block
+
+Before:
+```yaml
+- name: Register report server for publishing
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    report_server_host: "{{ lookup('env', 'REPORT_SERVER_HOST') }}"
+    report_server_port: "{{ lookup('env', 'REPORT_SERVER_PORT') | default('2222', true) }}"
+    report_url: "{{ lookup('env', 'REPORT_URL') }}"
+    report_filename: "failover_report_collection.html"
+```
+
+After:
+```yaml
+- name: Register report server for publishing
+  hosts: localhost
+  gather_facts: false
+
+  vars_files:
+    - vars/report.yml
+
+  vars:
+    report_server_host: "{{ lookup('env', 'REPORT_SERVER_HOST') }}"
+    report_server_port: "{{ lookup('env', 'REPORT_SERVER_PORT') | default('2222', true) }}"
+    report_url: "{{ lookup('env', 'REPORT_URL') }}"
+```
+
+- [ ] **Step 4: Verify Play 4 (SSH publish) needs no changes**
+
+The final play ("Publish failover report to web server") references `report_filename` from host vars set in Play 3's `add_host` task. It does not hardcode `report_filename`, so no changes needed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ansible/pb_deploy_report.yml
+git commit -m "feat: add GitHub Pages publishing play to deploy report (issue #26)
+
+Play 1 and Play 3 now import vars/report.yml instead of
+hardcoding report_filename. New Play 2 publishes the HTML report
+to the repo's docs/ directory via the GitHub Contents API,
+conditional on GITHUB_TOKEN being set. SSH path unchanged.
+
+Assisted-by: <model> <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Modify `pb_setup_aap.yml` — add GitHub credential type and conditional attachment
+
+**Files:**
+- Modify: `ansible/pb_setup_aap.yml:92` (add vars)
+- Modify: `ansible/pb_setup_aap.yml:128-166` (after NetBox credential, add GitHub credential type + credential)
+- Modify: `ansible/pb_setup_aap.yml:276-295` (Deploy Report JT — conditional credential list)
+
+- [ ] **Step 1: Add GitHub-related vars to the play vars block**
+
+After line 92 (`report_filename: "failover_report_collection.html"`), add:
+
+```yaml
+    github_token: "{{ lookup('env', 'GITHUB_TOKEN') | default('', true) }}"
+    github_repo: "{{ lookup('env', 'GITHUB_REPO') | default('leogallego/summit-netbox-circuits-demo', true) }}"
+    github_report_dir: "{{ lookup('env', 'GITHUB_REPORT_DIR') | default('docs', true) }}"
+    github_cred_name: "{{ aap_org_name }} GitHub"
+```
+
+- [ ] **Step 2: Add GitHub credential type and credential tasks**
+
+Insert these two tasks after the NetBox credential task (after line 166, before the Container Registry credential). Follow the exact pattern used by the NetBox credential type at lines 128-166.
+
+```yaml
+    # ── Controller: GitHub credential type ──────────────────────────────────
+
+    - name: Create GitHub credential type
+      ansible.controller.credential_type:
+        name: "GitHub"
+        kind: cloud
+        inputs:
+          fields:
+            - id: GITHUB_TOKEN
+              type: string
+              label: "Personal Access Token"
+              secret: true
+            - id: GITHUB_REPO
+              type: string
+              label: "Repository (owner/name)"
+            - id: GITHUB_REPORT_DIR
+              type: string
+              label: "Report directory in repo"
+          required:
+            - GITHUB_TOKEN
+            - GITHUB_REPO
+        injectors:
+          env:
+            GITHUB_TOKEN: "{{ '{{' }} GITHUB_TOKEN {{ '}}' }}"
+            GITHUB_REPO: "{{ '{{' }} GITHUB_REPO {{ '}}' }}"
+            GITHUB_REPORT_DIR: "{{ '{{' }} GITHUB_REPORT_DIR {{ '}}' }}"
+        state: present
+      when: github_token | length > 0
+      tags:
+        - credentials
+
+    # ── Controller: GitHub credential ─────────────────────────────────────────
+
+    - name: Create GitHub credential
+      ansible.controller.credential:
+        name: "{{ github_cred_name }}"
+        organization: "{{ aap_org_name }}"
+        credential_type: "GitHub"
+        inputs:
+          GITHUB_TOKEN: "{{ github_token }}"
+          GITHUB_REPO: "{{ github_repo }}"
+          GITHUB_REPORT_DIR: "{{ github_report_dir }}"
+        state: present
+      when: github_token | length > 0
+      tags:
+        - credentials
+```
+
+- [ ] **Step 3: Update Deploy Report job template — build credentials list dynamically**
+
+Replace the existing "Create Deploy Report job template" task (lines 276-295) so the credentials list includes the GitHub credential conditionally:
+
+Before:
+```yaml
+    - name: Create Deploy Report job template
+      ansible.controller.job_template:
+        name: "{{ jt_report_name }}"
+        organization: "{{ aap_org_name }}"
+        inventory: "{{ inventory_name }}"
+        project: "{{ controller_project_name }}"
+        playbook: "ansible/pb_deploy_report.yml"
+        execution_environment: "{{ ee_name }}"
+        job_type: run
+        ask_variables_on_launch: true
+        extra_vars:
+          failed_circuit: "IPLC-GB-PH-PRI"
+        credentials:
+          - "{{ netbox_cred_name }}"
+        description: >-
+          Generates and deploys the HTML failover report
+          to the report web server.
+        state: present
+      tags:
+        - job_templates
+```
+
+After:
+```yaml
+    - name: Create Deploy Report job template
+      ansible.controller.job_template:
+        name: "{{ jt_report_name }}"
+        organization: "{{ aap_org_name }}"
+        inventory: "{{ inventory_name }}"
+        project: "{{ controller_project_name }}"
+        playbook: "ansible/pb_deploy_report.yml"
+        execution_environment: "{{ ee_name }}"
+        job_type: run
+        ask_variables_on_launch: true
+        extra_vars:
+          failed_circuit: "IPLC-GB-PH-PRI"
+        credentials: >-
+          {{
+            [netbox_cred_name]
+            + ([github_cred_name] if github_token | length > 0 else [])
+          }}
+        description: >-
+          Generates and deploys the HTML failover report.
+          Publishes to GitHub Pages when GitHub credential is configured.
+        state: present
+      tags:
+        - job_templates
+```
+
+- [ ] **Step 4: Update the summary debug task**
+
+In the summary debug task at the end of the playbook (line 764+), add the GitHub credential to the output. After the `NetBox Cred:` line, add:
+
+```
+              {{ 'GitHub Cred:     ' ~ github_cred_name if github_token | length > 0 else 'GitHub Cred:     (not configured — report published locally only)' }}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ansible/pb_setup_aap.yml
+git commit -m "feat: add GitHub credential type and attachment to AAP setup (issue #26)
+
+Custom 'GitHub' credential type injects GITHUB_TOKEN, GITHUB_REPO,
+and GITHUB_REPORT_DIR as env vars. Credential and JT attachment
+are conditional on GITHUB_TOKEN being set in .env.
+
+Assisted-by: <model> <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Update `CLAUDE.md` — architecture and design decisions
+
+**Files:**
+- Modify: `CLAUDE.md:12-18` (architecture diagram)
+- Modify: `CLAUDE.md:64-65` (design decisions)
+
+- [ ] **Step 1: Update architecture diagram**
+
+Replace line 17 in the architecture block:
+
+Before:
+```
+      Step 2: pb_deploy_report.yml (re-query state, render Jinja2 HTML report, deploy to report server via SSH)
+```
+
+After:
+```
+      Step 2: pb_deploy_report.yml (re-query state, render Jinja2 HTML report, publish to GitHub Pages and/or deploy to report server via SSH)
+```
+
+- [ ] **Step 2: Add GitHub Pages design decision**
+
+After the `- **Report server**:` bullet (line 65), add a new bullet:
+
+```markdown
+- **GitHub Pages as default report target**: The HTML failover report is published to the repo's `docs/` directory via the GitHub Contents API (`ansible.builtin.uri`). GitHub Pages serves it from the `main` branch `/docs` path. The SSH/EC2 report server is kept as a conditional fallback.
+```
+
+- [ ] **Step 3: Update the Credentials and Secrets section**
+
+After the existing paragraph about `ansible/vars/netbox_creds.yml` (line 56), add:
+
+```markdown
+Report settings and GitHub Pages credentials are in `ansible/vars/report.yml` — imported via `vars_files:` in `pb_deploy_report.yml`. GitHub credential type in AAP injects `GITHUB_TOKEN`, `GITHUB_REPO`, `GITHUB_REPORT_DIR` as env vars.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: update CLAUDE.md for GitHub Pages report publishing (issue #26)
+
+Updates architecture diagram, adds GitHub Pages design decision,
+and documents the new report.yml vars file.
+
+Assisted-by: <model> <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Final verification
+
+- [ ] **Step 1: Verify all files are syntactically valid**
+
+```bash
+cd /home/lgallego/Claude/summit-netbox-circuits-demo
+python -c "import yaml; yaml.safe_load(open('ansible/vars/report.yml'))" && echo "report.yml OK"
+python -c "
+import yaml
+with open('ansible/pb_deploy_report.yml') as f:
+    docs = list(yaml.safe_load_all(f))
+    print(f'pb_deploy_report.yml: {len(docs)} plays OK')
+"
+python -c "
+import yaml
+with open('ansible/pb_setup_aap.yml') as f:
+    docs = list(yaml.safe_load_all(f))
+    print(f'pb_setup_aap.yml: {len(docs)} plays OK')
+"
+```
+
+Expected: All three files parse without errors. `pb_deploy_report.yml` should report 4 plays.
+
+- [ ] **Step 2: Verify no hardcoded `report_filename` remains in plays that should use the shared var**
+
+```bash
+grep -n 'report_filename:.*failover_report' ansible/pb_deploy_report.yml
+```
+
+Expected: No output (the hardcoded values have been removed from Play 1 and Play 3).
+
+- [ ] **Step 3: Verify `docs/` scaffolding**
+
+```bash
+test -f docs/.nojekyll && echo ".nojekyll exists" || echo "MISSING .nojekyll"
+test -f docs/index.html && echo "index.html exists" || echo "MISSING index.html"
+```
+
+Expected: Both files exist.
+
+- [ ] **Step 4: Check git status is clean**
+
+```bash
+git status
+```
+
+Expected: Working tree clean, all changes committed across Tasks 1–6.

--- a/docs/superpowers/specs/2026-05-04-github-pages-report-design.md
+++ b/docs/superpowers/specs/2026-05-04-github-pages-report-design.md
@@ -1,0 +1,165 @@
+# Deploy Failover Report to GitHub Pages Instead of SSH Server
+
+**Issue:** #26
+**Date:** 2026-05-04
+**Status:** Approved
+
+## Summary
+
+Replace the SSH-based report deployment (EC2 + nginx) with GitHub Pages as the default publishing target. The generated HTML failover report is pushed to a `docs/` directory in this repo via the GitHub Contents API. The SSH path is kept as a conditional fallback.
+
+## Report URL
+
+`https://leogallego.github.io/summit-netbox-circuits-demo/<report_filename>`
+
+Derived at runtime from `GITHUB_REPO` and the existing `report_filename` variable.
+
+## Shared Variables File (`ansible/vars/report.yml`)
+
+New vars file providing a single source of truth for report and GitHub settings. Imported via `vars_files:` in each play that needs these values. Each variable reads from its corresponding env var (set in `.env` locally, or injected by AAP credentials).
+
+```yaml
+report_filename: "{{ lookup('env', 'REPORT_FILENAME') | default('failover_report_collection.html', true) }}"
+github_token: "{{ lookup('env', 'GITHUB_TOKEN') | default('', true) }}"
+github_repo: "{{ lookup('env', 'GITHUB_REPO') | default('leogallego/summit-netbox-circuits-demo', true) }}"
+github_report_dir: "{{ lookup('env', 'GITHUB_REPORT_DIR') | default('docs', true) }}"
+```
+
+This eliminates the duplicated `report_filename` declarations across plays. Each play adds `vars/report.yml` to its `vars_files:` list.
+
+## Playbook Structure (`pb_deploy_report.yml`)
+
+Four plays, executed in order:
+
+### Play 1: Generate HTML report
+
+Remove the hardcoded `report_filename` from play vars. Add `vars/report.yml` to `vars_files:`. Everything else stays as-is.
+
+### Play 2: Publish to GitHub Pages (new)
+
+Conditional on `github_token` being set (non-empty). Imports `vars/report.yml`. Steps:
+
+1. **Slurp** the generated HTML file (`ansible.builtin.slurp`) to get base64-encoded content.
+2. **GET** current file SHA from GitHub Contents API:
+   - `GET /repos/{{ github_repo }}/contents/{{ github_report_dir }}/{{ report_filename }}`
+   - `Authorization: Bearer {{ github_token }}`
+   - Register result. Handle 404 (first deploy) by setting SHA to empty.
+3. **PUT** file to GitHub Contents API:
+   - `PUT /repos/{{ github_repo }}/contents/{{ github_report_dir }}/{{ report_filename }}`
+   - Body: `{ "message": "Update failover report — <circuit_cid>", "content": "<base64>", "sha": "<sha_or_omit>" }`
+   - Include `sha` field only when updating an existing file. On first deploy (GET returned 404), omit the `sha` field entirely — do not send an empty string.
+4. **Print** the GitHub Pages URL.
+
+### Play 3: Register report server
+
+Remove the hardcoded `report_filename` from play vars. Add `vars/report.yml` to `vars_files:`. Conditional on `REPORT_SERVER_HOST` (unchanged).
+
+### Play 4: Publish to web server via SSH (unchanged)
+
+Runs against `report_servers` group (only populated if Play 3 ran).
+
+### Fallback behavior
+
+If neither `GITHUB_TOKEN` nor `REPORT_SERVER_HOST` is set, only the local file is generated and its path is printed. No publishing occurs.
+
+## Environment Variables
+
+Added to `.env.example`:
+
+```
+# Report settings
+REPORT_FILENAME=failover_report_collection.html
+
+# GitHub Pages report publishing (optional — leave empty to skip)
+# Token needs contents:write scope on the target repo.
+GITHUB_TOKEN=
+GITHUB_REPO=leogallego/summit-netbox-circuits-demo
+GITHUB_REPORT_DIR=docs
+```
+
+- `REPORT_FILENAME`: Name of the generated HTML report file. Defaults to `failover_report_collection.html`.
+- `GITHUB_TOKEN`: GitHub Personal Access Token with `contents:write` scope.
+- `GITHUB_REPO`: Target repository in `owner/name` format. Defaults to this repo but can point elsewhere.
+- `GITHUB_REPORT_DIR`: Directory in the repo where the report is published. Defaults to `docs`.
+
+## AAP Credential Configuration (`pb_setup_aap.yml`)
+
+### Custom credential type
+
+A "GitHub" credential type following the NetBox pattern:
+
+```yaml
+name: "GitHub"
+kind: cloud
+inputs:
+  fields:
+    - id: GITHUB_TOKEN
+      type: string
+      label: "Personal Access Token"
+      secret: true
+    - id: GITHUB_REPO
+      type: string
+      label: "Repository (owner/name)"
+    - id: GITHUB_REPORT_DIR
+      type: string
+      label: "Report directory in repo"
+  required:
+    - GITHUB_TOKEN
+    - GITHUB_REPO
+injectors:
+  env:
+    GITHUB_TOKEN: "{{ GITHUB_TOKEN }}"
+    GITHUB_REPO: "{{ GITHUB_REPO }}"
+    GITHUB_REPORT_DIR: "{{ GITHUB_REPORT_DIR }}"
+```
+
+### Credential instance
+
+Created conditionally when `GITHUB_TOKEN` is set in `.env`:
+
+```yaml
+name: "GitHub (Summit Demo)"
+credential_type: "GitHub"
+inputs:
+  GITHUB_TOKEN: "{{ lookup('env', 'GITHUB_TOKEN') }}"
+  GITHUB_REPO: "{{ lookup('env', 'GITHUB_REPO') | default('leogallego/summit-netbox-circuits-demo', true) }}"
+  GITHUB_REPORT_DIR: "{{ lookup('env', 'GITHUB_REPORT_DIR') | default('docs', true) }}"
+```
+
+### Job template attachment
+
+The GitHub credential is attached to the Deploy Report job template **conditionally** — only when `GITHUB_TOKEN` is set. The credentials list is built dynamically:
+
+- Always: NetBox credential
+- Conditionally: GitHub credential (when `GITHUB_TOKEN` is set)
+
+## Repository Setup for GitHub Pages
+
+### New files in repo
+
+- **`docs/.nojekyll`**: Empty file. Prevents Jekyll processing so GitHub Pages serves raw HTML.
+- **`docs/index.html`**: Placeholder page with "No failover report generated yet" message. Designed to eventually list multiple report runs (the structure supports adding links to historical reports later).
+
+### GitHub Pages configuration
+
+Enable GitHub Pages on the repo: serve from `main` branch, `/docs` directory. This is a one-time repo setting — documented in setup instructions, can also be enabled via:
+
+```bash
+gh api repos/leogallego/summit-netbox-circuits-demo/pages \
+  --method POST \
+  --field source='{"branch":"main","path":"/docs"}'
+```
+
+## Documentation Updates
+
+- **`.env.example`**: Add `GITHUB_TOKEN`, `GITHUB_REPO`, `GITHUB_REPORT_DIR` with comments.
+- **`CLAUDE.md`**: Update architecture diagram and key design decisions to mention GitHub Pages as the default report target.
+
+## What Stays Unchanged
+
+- Play 1 (report generation) — untouched.
+- SSH deployment path (Plays 3-4) — kept as conditional fallback.
+- Terraform infrastructure — no changes (cleanup is a separate issue).
+- `reset.sh` — no changes needed (report is overwritten on each deploy).
+- Report template (`failover_report.html.j2`) — untouched.
+- `report_filename` value — same default, now sourced from `vars/report.yml` instead of hardcoded per-play.


### PR DESCRIPTION
## Summary

- Adds GitHub Pages as the default report publishing target, keeping the SSH/EC2 path as a conditional fallback
- New shared vars file (`ansible/vars/report.yml`) provides a single source of truth for `report_filename` and GitHub settings, replacing duplicated per-play declarations
- New Play 2 in `pb_deploy_report.yml` uses `ansible.builtin.slurp` + `ansible.builtin.uri` (GitHub Contents API) to push the generated HTML report to the repo's `docs/` directory
- Custom "GitHub" credential type in `pb_setup_aap.yml` injects `GITHUB_TOKEN`, `GITHUB_REPO`, `GITHUB_REPORT_DIR` as env vars — conditionally created and attached to the Deploy Report job template

## Changes

| File | What changed |
|------|-------------|
| `ansible/vars/report.yml` | **New** — shared vars for report settings + GitHub config |
| `docs/.nojekyll` + `docs/index.html` | **New** — GitHub Pages scaffolding |
| `.env.example` | Added `REPORT_FILENAME`, `GITHUB_TOKEN`, `GITHUB_REPO`, `GITHUB_REPORT_DIR` |
| `ansible/pb_deploy_report.yml` | Added GitHub Pages publish play; all plays import `vars/report.yml` |
| `ansible/pb_setup_aap.yml` | Added GitHub credential type, credential, conditional JT attachment |
| `CLAUDE.md` | Updated architecture diagram and design decisions |

## How it works

1. Play 1 generates the HTML report (unchanged logic, now uses shared vars)
2. **Play 2 (new)**: If `GITHUB_TOKEN` is set, slurps the report, GETs the current file SHA from GitHub, PUTs the updated content via Contents API
3. Play 3-4: SSH path runs if `REPORT_SERVER_HOST` is set (unchanged)
4. If neither token is set, only the local file is generated

## Setup

1. Create a fine-grained PAT with `contents:write` scope on the target repo
2. Add to `.env`: `GITHUB_TOKEN=ghp_...`
3. Enable GitHub Pages on the repo: serve from `main` branch, `/docs` directory

## Test plan

- [ ] Run `pb_deploy_report.yml` with `GITHUB_TOKEN` set — verify report appears at GitHub Pages URL
- [ ] Run without `GITHUB_TOKEN` — verify Play 2 is skipped, SSH path still works if configured
- [ ] Run without both tokens — verify only local file is generated
- [ ] Run `pb_setup_aap.yml` with `GITHUB_TOKEN` — verify credential type and credential are created
- [ ] Run `pb_setup_aap.yml` without `GITHUB_TOKEN` — verify GitHub credential tasks are skipped
- [ ] Verify YAML syntax: `python3 -c "import yaml; yaml.safe_load(open('ansible/pb_deploy_report.yml'))"`

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)