### PR TITLE
fix: bump EE image to v3.22-3

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -65,7 +65,7 @@ All resources are scoped to the `SummitCollection` organization (configurable vi
 | Credential | SummitCollection Network Router | Network credential for Cisco router (conditional) |
 | Inventory | SummitCollection Localhost | Localhost + report server hosts |
 | Project | SummitCollection NetBox Circuits Demo | Git source — this repository, synced on launch |
-| Execution Environment | SummitCollection Execution Environment | `quay.io/acme_corp/netbox-summit-2026-ee:v3.22` |
+| Execution Environment | SummitCollection Execution Environment | `quay.io/acme_corp/netbox-summit-2026-ee:v3.22-3` |
 | Job Template | SummitCollection Circuit Failover | Runs `pb_circuit_failover.yml`, accepts `failed_circuit` extra var |
 | Job Template | SummitCollection Deploy Report | Runs `pb_deploy_report.yml`, accepts `failed_circuit` extra var |
 | Job Template | SummitCollection Reset Demo | Runs `pb_reset_demo.yml` |
@@ -73,7 +73,7 @@ All resources are scoped to the `SummitCollection` organization (configurable vi
 
 ### Execution Environment
 
-The project EE (`quay.io/acme_corp/netbox-summit-2026-ee:v3.22`) includes all required collections and Python dependencies:
+The project EE (`quay.io/acme_corp/netbox-summit-2026-ee:v3.22-3`) includes all required collections and Python dependencies:
 - `netbox.netbox` >= 3.22.0, `ansible.controller`, `ansible.eda`
 - `cisco.ios`, `ansible.netcommon`, `ansible.utils`
 - `pynetbox` >= 7.6.0

--- a/ansible-navigator.yml
+++ b/ansible-navigator.yml
@@ -3,9 +3,9 @@ ansible-navigator:
   execution-environment:
     container-engine: podman
     enabled: true
-    image: quay.io/acme_corp/netbox-summit-2026-ee:v3.22
+    image: quay.io/acme_corp/netbox-summit-2026-ee:v3.22-3
     pull:
-      policy: never
+      policy: missing
     environment-variables:
       pass:
         - AWS_ACCESS_KEY_ID

--- a/ansible/pb_setup_aap.yml
+++ b/ansible/pb_setup_aap.yml
@@ -77,7 +77,7 @@
     router_mgmt_iface_name: "GigabitEthernet1"
     # Execution Environment
     ee_name: "{{ aap_org_name }} Execution Environment"
-    ee_image: "quay.io/acme_corp/netbox-summit-2026-ee:v3.22"
+    ee_image: "quay.io/acme_corp/netbox-summit-2026-ee:v3.22-3"
     registry_cred_name: "{{ aap_org_name }} Container Registry"
     rh_registry_cred_name: "{{ aap_org_name }} Red Hat Registry"
     galaxy_cred_name: "{{ aap_org_name }} Automation Hub"


### PR DESCRIPTION
## Summary
- Update EE image tag from `v3.22` to `v3.22-3` across SETUP.md, ansible-navigator.yml, and pb_setup_aap.yml
- Change ansible-navigator pull policy from `never` to `missing`

## Test plan
- [ ] Verify `ansible-navigator` pulls the correct EE image
- [ ] Run `pb_setup_aap.yml` and confirm the EE is registered with the updated tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)