### PR TITLE
docs: update CLAUDE.md with correct EE image name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,9 +67,9 @@ Infrastructure variables (`REPORT_SERVER_HOST`, `ROUTER_IP`, etc.) are written t
 - **Report server**: EC2 instance provisioned by Terraform, nginx with HTTPS, SSH on port 2222.
 - **GitHub Pages as default report target**: The HTML failover report is published to the repo's `docs/` directory via the GitHub Contents API (`ansible.builtin.uri`). GitHub Pages serves it from the `main` branch `/docs` path. The SSH/EC2 report server is kept as a conditional fallback.
 - **NetBox circuit tag `dd`**: All demo-relevant circuits are tagged `dd` in NetBox. This tag scopes all queries — backup discovery, reset, and report generation only touch `dd`-tagged circuits.
-- **NetBox v4.5 token compatibility**: v2 tokens (default on NetBox 4.5+) work with pynetbox >= 7.6.0. The `network-netbox-eda-ee` EE ships pynetbox 7.6.1. Pass the full `nbt_<key>.<token>` format.
+- **NetBox v4.5 token compatibility**: v2 tokens (default on NetBox 4.5+) work with pynetbox >= 7.6.0. The `netbox-summit-2026-ee` EE ships pynetbox 7.6.1. Pass the full `nbt_<key>.<token>` format.
 - **Webhook body template**: Use empty body_template (NetBox default payload). Custom templates with `{{ data | tojson }}` fail on NetBox v4.5.
-- **Always test with the EE**: Use `ansible-navigator` with `quay.io/acme_corp/network-netbox-eda-ee:latest` for all local testing. Never use bare `ansible-playbook` on host Python — it bypasses the EE's pinned collections and Python dependencies, leading to version mismatches that don't reproduce on AAP.
+- **Always test with the EE**: Use `ansible-navigator` with `quay.io/acme_corp/netbox-summit-2026-ee:v3.22-3` for all local testing. Never use bare `ansible-playbook` on host Python — it bypasses the EE's pinned collections and Python dependencies, leading to version mismatches that don't reproduce on AAP.
 
 ## Demo Circuits
 


### PR DESCRIPTION
## Summary
- Fix stale EE name: `network-netbox-eda-ee` → `netbox-summit-2026-ee`
- Fix stale EE tag: `latest` → `v3.22-3`

## Test plan
- [ ] Verify CLAUDE.md references match actual EE image in use

🤖 Generated with [Claude Code](https://claude.com/claude-code)