### PR TITLE
fix: docs audit — stale refs and inaccuracies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,6 @@ AH_TOKEN=your_automation_hub_token_here
 
 # Report publishing — GitHub Pages (optional — leave empty to skip)
 # Token needs contents:write scope on the target repo.
-REPORT_FILENAME=failover_report_collection.html
 GITHUB_TOKEN=
 GITHUB_REPO=leogallego/summit-netbox-circuits-demo
 GITHUB_REPORT_DIR=docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ cp .env.example .env        # fill in credentials
 
 # Run playbooks locally (sources .env, uses localhost inventory)
 ./run-playbook.sh ansible/pb_circuit_failover.yml
-./run-playbook.sh ansible/pb_circuit_failover.yml --extra-vars "failed_circuit=IPLC-GB-JP-PRI"
+./run-playbook.sh ansible/pb_circuit_failover.yml --extra-vars "failed_circuit=IPLC-GB-AT-PRI"
 ./run-playbook.sh ansible/pb_deploy_report.yml --extra-vars "failed_circuit=IPLC-GB-AT-PRI"
 
 # Local testing (no AAP needed)
@@ -67,7 +67,7 @@ Infrastructure variables (`REPORT_SERVER_HOST`, `ROUTER_IP`, etc.) are written t
 - **Report server**: EC2 instance provisioned by Terraform, nginx with HTTPS, SSH on port 2222.
 - **GitHub Pages as default report target**: The HTML failover report is published to the repo's `docs/` directory via the GitHub Contents API (`ansible.builtin.uri`). GitHub Pages serves it from the `main` branch `/docs` path. The SSH/EC2 report server is kept as a conditional fallback.
 - **NetBox circuit tag `dd`**: All demo-relevant circuits are tagged `dd` in NetBox. This tag scopes all queries — backup discovery, reset, and report generation only touch `dd`-tagged circuits.
-- **NetBox v4.5 token compatibility**: v2 tokens (default on NetBox 4.5+) work with pynetbox >= 7.6.0. The `netbox-summit-2026-ee` EE ships pynetbox 7.6.1. Pass the full `nbt_<key>.<token>` format.
+- **NetBox v4.5 token compatibility**: Use v1 tokens — v2 tokens (default on NetBox 4.5+) are untested with the `netbox.netbox` collection. When creating a token, explicitly request v1 format in the NetBox UI or provisioning API.
 - **Webhook body template**: Use empty body_template (NetBox default payload). Custom templates with `{{ data | tojson }}` fail on NetBox v4.5.
 - **Always test with the EE**: Use `ansible-navigator` with `quay.io/acme_corp/netbox-summit-2026-ee:v3.22-3` for all local testing. Never use bare `ansible-playbook` on host Python — it bypasses the EE's pinned collections and Python dependencies, leading to version mismatches that don't reproduce on AAP.
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ ansible/
   pb_deploy_report.yml      # Workflow Step 2: generate timestamped report, publish to GitHub Pages
   pb_reset_demo.yml         # Reset all dd-tagged circuits to starting state
   pb_seed_netbox.yml        # Seed NetBox with demo data (sites, circuits, interfaces, IPs, cables)
+  pb_launch_demo_router.yml # Launch CSR 1000v 16.12 on AWS for router testing
   pb_setup_local_netbox.yml # Deploy local NetBox via Podman for testing
   pb_setup_local_eda.yml    # Deploy local EDA environment for testing
   templates/

--- a/ansible-navigator.yml
+++ b/ansible-navigator.yml
@@ -37,7 +37,6 @@ ansible-navigator:
         - ROUTER_USERNAME
         - ROUTER_PRIMARY_GW
         - ROUTER_BACKUP_GW
-        - GITHUB_PAGES_REPO
 
   mode: stdout
 

--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: netbox.netbox
-    version: ">=3.19.0"
+    version: ">=3.22.0"
   - name: ansible.controller
     version: ">=4.7.0"
   - name: ansible.eda

--- a/run-playbook.sh
+++ b/run-playbook.sh
@@ -3,7 +3,7 @@
 # All settings (EE image, env injection, mode) come from ansible-navigator.yml.
 #
 # Usage: ./run-playbook.sh ansible/pb_circuit_failover.yml [extra args]
-#        ./run-playbook.sh ansible/pb_circuit_failover.yml --extra-vars "failed_circuit=IPLC-GB-JP-PRI"
+#        ./run-playbook.sh ansible/pb_circuit_failover.yml --extra-vars "failed_circuit=IPLC-GB-AT-PRI"
 
 set -e
 


### PR DESCRIPTION
## Summary
- Sync NetBox token guidance to "use v1, v2 untested" across CLAUDE.md and SETUP.md
- Fix invalid example circuit CID `IPLC-GB-JP-PRI` → `IPLC-GB-AT-PRI` in CLAUDE.md and run-playbook.sh
- Bump `netbox.netbox` collection requirement from `>=3.19.0` to `>=3.22.0`
- Remove stale `GITHUB_PAGES_REPO` env var from ansible-navigator.yml (`GITHUB_REPO` is the one used)
- Remove stale `REPORT_FILENAME` from .env.example (replaced by dynamic filenames in #37)
- Add `pb_launch_demo_router.yml` to README repository layout

## Test plan
- [ ] Verify example commands in CLAUDE.md use valid circuit CIDs
- [ ] Confirm `GITHUB_REPO` still passes through to EE correctly
- [ ] Run syntax check on all playbooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)