### PR TITLE
Split router config into separate playbook for legacy-crypto EE

### DIFF
--- a/ansible/pb_circuit_failover.yml
+++ b/ansible/pb_circuit_failover.yml
@@ -355,6 +355,44 @@
         verbosity: 0
       when: backup.status.value != 'active'
 
+    # ── Pass router targets to next workflow step ──────────────────────────────
+    # AAP propagates set_stats artifacts as extra_vars to subsequent nodes.
+
+    - name: Build router target list for config push
+      ansible.builtin.set_fact:
+        router_targets: >-
+          {{
+            router_targets | default([]) + [{
+              'name': item.name,
+              'ip': item.primary_ip4.address | ansible.utils.ipaddr('address'),
+              'failed_gw': (failed_term_ips[item.name][0].address
+                            | ansible.utils.ipaddr('network/prefix')
+                            | ansible.utils.nthhost(1))
+                           if (failed_term_ips is defined and item.name in failed_term_ips)
+                           else lookup('env', 'ROUTER_PRIMARY_GW') | default('172.16.0.1', true),
+              'backup_gw': (backup_term_ips[item.name][0].address
+                            | ansible.utils.ipaddr('network/prefix')
+                            | ansible.utils.nthhost(1))
+                           if (backup_term_ips is defined and item.name in backup_term_ips)
+                           else lookup('env', 'ROUTER_BACKUP_GW') | default('172.16.1.1', true)
+            }]
+          }}
+      loop: >-
+        {{
+          all_routers
+          | selectattr('primary_ip4', 'defined')
+          | selectattr('primary_ip4', 'ne', none)
+          | list
+        }}
+      loop_control:
+        label: "{{ item.name }}"
+
+    - name: Pass failover data to next workflow step
+      ansible.builtin.set_stats:
+        data:
+          router_targets: "{{ router_targets | default([]) }}"
+        per_host: false
+
     - name: Failover complete
       ansible.builtin.debug:
         msg: |
@@ -362,5 +400,6 @@
             Primary:  {{ primary.cid }} -> Offline
             Backup:   {{ backup.cid }} ({{ backup.provider.name }}, {{ backup.commit_rate // 1000 }} Mbps)
             Routers:  {{ all_routers | map(attribute='name') | join(', ') }}
+            Targets for config push: {{ router_targets | default([]) | map(attribute='name') | join(', ') | default('none (simulated only)') }}
           Next workflow steps: router config push, then report generation.
         verbosity: 0

--- a/ansible/pb_deploy_report.yml
+++ b/ansible/pb_deploy_report.yml
@@ -1,14 +1,15 @@
 ---
 # pb_deploy_report.yml
 #
-# Second step in the Circuit Failover workflow.
+# Step 3 of 3 in the Circuit Failover workflow.
 #
 # Re-queries NetBox for the current state of the failed circuit and its
 # backup, generates the HTML failover report, then deploys it to the
 # report web server.
 #
 # Expects 'failed_circuit' to be set as an extra var (passed through
-# from the workflow).
+# from the workflow). Optionally receives router_config_applied (bool)
+# and router_config_error (string) via set_stats from step 2.
 #
 # Usage (manual):
 #   ansible-playbook ansible/pb_deploy_report.yml \
@@ -233,6 +234,8 @@
         candidates: "{{ backup_candidates }}"
         netbox_base_url: "{{ netbox_url }}"
         gateways: "{{ router_gateways | default({}) }}"
+        router_config_applied: "{{ router_config_applied | default(true) }}"
+        router_config_error: "{{ router_config_error | default('') }}"
 
     - name: Report generated
       ansible.builtin.debug:

--- a/ansible/pb_router_config.yml
+++ b/ansible/pb_router_config.yml
@@ -7,289 +7,73 @@
 # pb_circuit_failover.yml has updated NetBox, and before
 # pb_deploy_report.yml generates the incident report.
 #
-# Self-contained: re-queries NetBox for the failed circuit, discovers
-# sites and routers, and derives gateway IPs from cable wiring. Can be
-# tested independently without the workflow.
+# Receives router targets via set_stats artifacts from the failover
+# step (AAP propagates these as extra_vars). No NetBox dependency —
+# this playbook runs on the legacy-crypto EE which only needs
+# cisco.ios and ansible.netcommon.
 #
 # Uses set_stats to pass router_config_applied (bool) and
-# router_config_error to the report step. The report template can
-# render a warning banner when router config was not applied.
+# router_config_error to the report step.
 #
-# Requires the legacy-crypto EE when targeting IOS-XE < 17 routers
-# (SHA-1 SSH). For IOS-XE 17+ or simulated routers, the standard EE
-# works fine.
+# Input variables (from workflow extra_vars / set_stats):
+#   failed_circuit  — CID of the failed circuit (passed through workflow)
+#   router_targets  — list of dicts from failover step:
+#     [{ name, ip, failed_gw, backup_gw }, ...]
 #
-# Usage (manual):
-#   ./run-playbook.sh ansible/pb_router_config.yml \
-#     --extra-vars "failed_circuit=IPLC-GB-AT-PRI"
+# Usage (standalone testing):
+#   ansible-playbook ansible/pb_router_config.yml \
+#     -e failed_circuit=IPLC-GB-AT-PRI \
+#     -e '{"router_targets": [{"name": "rtr1", "ip": "10.0.0.1", "failed_gw": "172.16.0.1", "backup_gw": "172.16.1.1"}]}'
 
 - name: "Push failover routing — {{ failed_circuit }}"
   hosts: localhost
   connection: local
   gather_facts: false
 
-  vars_files:
-    - vars/netbox_creds.yml
-
   tasks:
-    # ── Query failed circuit ───────────────────────────────────────────────────
-
-    - name: Query failed circuit from NetBox
-      ansible.builtin.set_fact:
-        failed_result: >-
-          {{ query('netbox.netbox.nb_lookup', 'circuits',
-                   api_endpoint=netbox_url,
-                   token=netbox_token,
-                   api_filter='cid=' ~ failed_circuit,
-                   validate_certs=netbox_validate_certs,
-                   raw_data=true) }}
-
-    - name: Validate circuit exists
-      ansible.builtin.assert:
-        that: failed_result | length > 0
-        fail_msg: "Circuit {{ failed_circuit }} not found in NetBox"
-
-    - name: Set failed circuit facts
-      ansible.builtin.set_fact:
-        primary: "{{ failed_result | first }}"
-
-    # ── Discover sites from terminations ──────────────────────────────────────
-
-    - name: Query failed circuit terminations
-      ansible.builtin.set_fact:
-        primary_terms: >-
-          {{ query('netbox.netbox.nb_lookup', 'circuit-terminations',
-                   api_endpoint=netbox_url,
-                   token=netbox_token,
-                   api_filter='circuit_id=' ~ primary.id,
-                   validate_certs=netbox_validate_certs,
-                   raw_data=true) }}
-
-    - name: Assert terminations exist for both sides
-      ansible.builtin.assert:
-        that:
-          - primary_terms | selectattr('term_side', 'eq', 'A') | list | length > 0
-          - primary_terms | selectattr('term_side', 'eq', 'Z') | list | length > 0
-        fail_msg: >-
-          Circuit {{ failed_circuit }} is missing A/Z terminations in NetBox.
-
-    - name: Set A-side and Z-side sites
-      ansible.builtin.set_fact:
-        a_side_site: "{{ (primary_terms | selectattr('term_side', 'eq', 'A') | first).termination }}"
-        z_side_site: "{{ (primary_terms | selectattr('term_side', 'eq', 'Z') | first).termination }}"
-
-    # ── Find the active backup circuit ────────────────────────────────────────
-
-    - name: Query dd-tagged circuits at A-side site
-      ansible.builtin.set_fact:
-        a_site_circuits: >-
-          {{ query('netbox.netbox.nb_lookup', 'circuits',
-                   api_endpoint=netbox_url,
-                   token=netbox_token,
-                   api_filter='site_id=' ~ a_side_site.id ~ ' tag=dd',
-                   validate_certs=netbox_validate_certs,
-                   raw_data=true) }}
-
-    - name: Query dd-tagged circuits at Z-side site
-      ansible.builtin.set_fact:
-        z_site_circuits: >-
-          {{ query('netbox.netbox.nb_lookup', 'circuits',
-                   api_endpoint=netbox_url,
-                   token=netbox_token,
-                   api_filter='site_id=' ~ z_side_site.id ~ ' tag=dd',
-                   validate_certs=netbox_validate_certs,
-                   raw_data=true) }}
-
-    - name: Find backup circuit (active, present at both sites, not the failed one)
-      ansible.builtin.set_fact:
-        z_circuit_ids: "{{ z_site_circuits | map(attribute='id') | list }}"
-
-    - name: Build backup candidate list
-      ansible.builtin.set_fact:
-        backup_candidates: >-
-          {{
-            a_site_circuits
-            | selectattr('id', 'in', z_circuit_ids)
-            | rejectattr('id', 'eq', primary.id)
-            | selectattr('status.value', 'eq', 'active')
-            | list
-          }}
-
-    - name: Skip if no active backup found
-      when: backup_candidates | length == 0
+    - name: Skip if no router targets provided
+      when: router_targets | default([]) | length == 0
       block:
-        - name: No active backup — nothing to route to
+        - name: No router targets — skipping config push
           ansible.builtin.debug:
             msg: >-
-              No active backup circuit found between
-              {{ a_side_site.display }} and {{ z_side_site.display }}.
-              Skipping router config push.
+              No router targets received from failover step.
+              This is normal when all routers are simulated (no real IPs in NetBox).
             verbosity: 0
 
-        - name: Flag router config as skipped
+        - name: Flag router config as skipped (no targets)
           ansible.builtin.set_stats:
             data:
               router_config_applied: false
-              router_config_error: >-
-                No active backup circuit found between
-                {{ a_side_site.display }} and {{ z_side_site.display }}
+              router_config_error: "No router targets provided — simulated routers only"
             per_host: false
 
-        - name: End play — no backup to route to
+        - name: End play — no targets
           ansible.builtin.meta: end_play
 
-    - name: Select backup (highest commit rate)
-      ansible.builtin.set_fact:
-        backup: "{{ backup_candidates | sort(attribute='commit_rate', reverse=true) | first }}"
+    # ── Build dynamic inventory from set_stats data ──────────────────────────
 
-    # ── Query backup terminations ──────────────────────────────────────────────
-
-    - name: Query backup circuit terminations
-      ansible.builtin.set_fact:
-        backup_terms: >-
-          {{ query('netbox.netbox.nb_lookup', 'circuit-terminations',
-                   api_endpoint=netbox_url,
-                   token=netbox_token,
-                   api_filter='circuit_id=' ~ backup.id,
-                   validate_certs=netbox_validate_certs,
-                   raw_data=true) }}
-
-    # ── Derive gateway IPs from cable wiring ──────────────────────────────────
-
-    - name: Check if circuits have cable wiring
-      ansible.builtin.set_fact:
-        circuits_have_cables: >-
-          {{ (primary_terms | map(attribute='link_peers', default=[]) | select | list | length > 0)
-             and (backup_terms | map(attribute='link_peers', default=[]) | select | list | length > 0) }}
-
-    - name: Query IPs for cabled interfaces on failed circuit
-      ansible.builtin.set_fact:
-        failed_term_ips: >-
-          {{ failed_term_ips | default({}) | combine({
-               item.link_peers[0].device.name:
-                 query('netbox.netbox.nb_lookup', 'ip-addresses',
-                       api_endpoint=netbox_url,
-                       token=netbox_token,
-                       api_filter='interface_id=' ~ item.link_peers[0].id,
-                       validate_certs=netbox_validate_certs,
-                       raw_data=true)
-             }) }}
-      loop: "{{ primary_terms | selectattr('link_peers', 'defined') | list }}"
-      loop_control:
-        label: "{{ item.link_peers[0].device.name | default('uncabled') }}"
-      when:
-        - circuits_have_cables | bool
-        - item.link_peers | default([]) | length > 0
-
-    - name: Query IPs for cabled interfaces on backup circuit
-      ansible.builtin.set_fact:
-        backup_term_ips: >-
-          {{ backup_term_ips | default({}) | combine({
-               item.link_peers[0].device.name:
-                 query('netbox.netbox.nb_lookup', 'ip-addresses',
-                       api_endpoint=netbox_url,
-                       token=netbox_token,
-                       api_filter='interface_id=' ~ item.link_peers[0].id,
-                       validate_certs=netbox_validate_certs,
-                       raw_data=true)
-             }) }}
-      loop: "{{ backup_terms | selectattr('link_peers', 'defined') | list }}"
-      loop_control:
-        label: "{{ item.link_peers[0].device.name | default('uncabled') }}"
-      when:
-        - circuits_have_cables | bool
-        - item.link_peers | default([]) | length > 0
-
-    # ── Query routers at both sites ───────────────────────────────────────────
-
-    - name: Query routers at A-side site
-      ansible.builtin.set_fact:
-        a_side_routers: >-
-          {{ query('netbox.netbox.nb_lookup', 'devices',
-                   api_endpoint=netbox_url,
-                   token=netbox_token,
-                   api_filter='site_id=' ~ a_side_site.id ~ ' role=router tag=dd',
-                   validate_certs=netbox_validate_certs,
-                   raw_data=true) }}
-
-    - name: Query routers at Z-side site
-      ansible.builtin.set_fact:
-        z_side_routers: >-
-          {{ query('netbox.netbox.nb_lookup', 'devices',
-                   api_endpoint=netbox_url,
-                   token=netbox_token,
-                   api_filter='site_id=' ~ z_side_site.id ~ ' role=router tag=dd',
-                   validate_certs=netbox_validate_certs,
-                   raw_data=true) }}
-
-    - name: Combine router list
-      ansible.builtin.set_fact:
-        all_routers: "{{ a_side_routers + z_side_routers }}"
-
-    - name: Filter routers with real IPs
-      ansible.builtin.set_fact:
-        routers_with_ip: >-
-          {{
-            all_routers
-            | selectattr('primary_ip4', 'defined')
-            | selectattr('primary_ip4', 'ne', none)
-            | list
-          }}
-
-    - name: Skip if no routers with real IPs
-      when: routers_with_ip | length == 0
-      block:
-        - name: No routers with IPs — skipping config push
-          ansible.builtin.debug:
-            msg: >-
-              No routers with primary_ip4 found at
-              {{ a_side_site.display }} or {{ z_side_site.display }}.
-              Router config push skipped (simulated routers only).
-            verbosity: 0
-
-        - name: Flag router config as skipped (no real routers)
-          ansible.builtin.set_stats:
-            data:
-              router_config_applied: false
-              router_config_error: "No routers with real IPs found — simulated routers only"
-            per_host: false
-
-        - name: End play — no real routers
-          ansible.builtin.meta: end_play
-
-    # ── Build dynamic inventory ───────────────────────────────────────────────
-
-    - name: Add routers with real IPs to dynamic inventory
+    - name: Add routers to dynamic inventory
       ansible.builtin.add_host:
         name: "{{ item.name }}"
         groups: failover_routers
-        ansible_host: "{{ item.primary_ip4.address | ansible.utils.ipaddr('address') }}"
+        ansible_host: "{{ item.ip }}"
         ansible_user: "{{ lookup('env', 'ROUTER_USERNAME') | default('iosuser', true) }}"
         ansible_password: "{{ lookup('env', 'ROUTER_PASSWORD') | default(omit, true) }}"
         ansible_network_os: cisco.ios.ios
         ansible_connection: ansible.netcommon.network_cli
         ansible_network_cli_ssh_type: paramiko
-        failed_gw: >-
-          {{ (failed_term_ips[item.name][0].address
-              | ansible.utils.ipaddr('network/prefix')
-              | ansible.utils.nthhost(1))
-             if (failed_term_ips is defined and item.name in failed_term_ips)
-             else lookup('env', 'ROUTER_PRIMARY_GW') | default('172.16.0.1', true) }}
-        backup_gw: >-
-          {{ (backup_term_ips[item.name][0].address
-              | ansible.utils.ipaddr('network/prefix')
-              | ansible.utils.nthhost(1))
-             if (backup_term_ips is defined and item.name in backup_term_ips)
-             else lookup('env', 'ROUTER_BACKUP_GW') | default('172.16.1.1', true) }}
-      loop: "{{ routers_with_ip }}"
+        failed_gw: "{{ item.failed_gw }}"
+        backup_gw: "{{ item.backup_gw }}"
+      loop: "{{ router_targets }}"
       loop_control:
         label: "{{ item.name }}"
 
     - name: Show router targets
       ansible.builtin.debug:
         msg: >-
-          Pushing failover config to {{ routers_with_ip | length }} router(s):
-          {{ routers_with_ip | map(attribute='name') | join(', ') }}
+          Pushing failover config to {{ router_targets | length }} router(s):
+          {{ router_targets | map(attribute='name') | join(', ') }}
         verbosity: 0
 
 # ── Play 2: Push failover routing to real routers ─────────────────────────────

--- a/ansible/pb_router_config.yml
+++ b/ansible/pb_router_config.yml
@@ -1,51 +1,37 @@
 ---
-# pb_circuit_failover.yml
+# pb_router_config.yml
 #
-# Automated circuit failover driven by NetBox as the Source of Truth.
+# Push failover routing configuration to real routers.
 #
-# Triggered by a NetBox webhook (via AAP workflow) when a circuit status
-# changes to 'offline'. Can also be run manually for testing.
+# Step 2 of 3 in the Circuit Failover workflow. Runs after
+# pb_circuit_failover.yml has updated NetBox, and before
+# pb_deploy_report.yml generates the incident report.
 #
-# Step 1 of 3 in the Circuit Failover workflow:
-#   1. pb_circuit_failover.yml — query NetBox, discover backup, update SoT
-#   2. pb_router_config.yml — push routing config to real routers (legacy EE)
-#   3. pb_deploy_report.yml — generate and deploy HTML incident report
+# Self-contained: re-queries NetBox for the failed circuit, discovers
+# sites and routers, and derives gateway IPs from cable wiring. Can be
+# tested independently without the workflow.
 #
-# What it does:
-#   1. Queries the failed circuit from NetBox
-#   2. Discovers the A/Z sites from circuit terminations
-#   3. Finds the best available backup circuit between the same sites
-#   4. Shows simulated router config for routers without real IPs
-#   5. Updates NetBox: marks primary offline, backup active
+# Uses set_stats to pass router_config_applied (bool) and
+# router_config_error to the report step. The report template can
+# render a warning banner when router config was not applied.
+#
+# Requires the legacy-crypto EE when targeting IOS-XE < 17 routers
+# (SHA-1 SSH). For IOS-XE 17+ or simulated routers, the standard EE
+# works fine.
 #
 # Usage (manual):
-#   ansible-playbook ansible/pb_circuit_failover.yml
-#   ansible-playbook ansible/pb_circuit_failover.yml \
+#   ./run-playbook.sh ansible/pb_router_config.yml \
 #     --extra-vars "failed_circuit=IPLC-GB-AT-PRI"
-#
-# Usage (from AAP workflow):
-#   Pass the circuit CID in the extra_vars payload as 'failed_circuit'.
 
-- name: "Automated Circuit Failover — {{ failed_circuit }}"
+- name: "Push failover routing — {{ failed_circuit }}"
   hosts: localhost
   connection: local
-  gather_facts: true
+  gather_facts: false
 
   vars_files:
     - vars/netbox_creds.yml
 
-  vars:
-    report_dir: "{{ playbook_dir }}/reports"
-
   tasks:
-    # ── Setup ─────────────────────────────────────────────────────────────────
-
-    - name: Create report directory
-      ansible.builtin.file:
-        path: "{{ report_dir }}"
-        state: directory
-        mode: "0755"
-
     # ── Query failed circuit ───────────────────────────────────────────────────
 
     - name: Query failed circuit from NetBox
@@ -63,17 +49,13 @@
         that: failed_result | length > 0
         fail_msg: "Circuit {{ failed_circuit }} not found in NetBox"
 
-    - name: Set primary circuit facts
+    - name: Set failed circuit facts
       ansible.builtin.set_fact:
         primary: "{{ failed_result | first }}"
 
-    - name: Skip if circuit is not in a failed state
-      ansible.builtin.meta: end_play
-      when: primary.status.value not in ['offline', 'failed']
-
     # ── Discover sites from terminations ──────────────────────────────────────
 
-    - name: Query circuit terminations
+    - name: Query failed circuit terminations
       ansible.builtin.set_fact:
         primary_terms: >-
           {{ query('netbox.netbox.nb_lookup', 'circuit-terminations',
@@ -83,36 +65,20 @@
                    validate_certs=netbox_validate_certs,
                    raw_data=true) }}
 
-    - name: Debug terminations response
-      ansible.builtin.debug:
-        msg: "Terminations count={{ primary_terms | length }} results={{ primary_terms | map(attribute='term_side') | list }}"
-        verbosity: 1
-
     - name: Assert terminations exist for both sides
       ansible.builtin.assert:
         that:
           - primary_terms | selectattr('term_side', 'eq', 'A') | list | length > 0
           - primary_terms | selectattr('term_side', 'eq', 'Z') | list | length > 0
         fail_msg: >-
-          Circuit {{ failed_circuit }} (id={{ primary.id }}) is missing A/Z terminations in NetBox.
-          Found {{ primary_terms | length }} termination(s):
-          {{ primary_terms | map(attribute='term_side') | list }}.
-          Please add site terminations for this circuit in NetBox.
+          Circuit {{ failed_circuit }} is missing A/Z terminations in NetBox.
 
     - name: Set A-side and Z-side sites
       ansible.builtin.set_fact:
         a_side_site: "{{ (primary_terms | selectattr('term_side', 'eq', 'A') | first).termination }}"
         z_side_site: "{{ (primary_terms | selectattr('term_side', 'eq', 'Z') | first).termination }}"
 
-    - name: Show discovered sites
-      ansible.builtin.debug:
-        msg: >-
-          {{ failed_circuit }} connects
-          {{ a_side_site.display }} ↔ {{ z_side_site.display }}.
-          Searching for backup circuits...
-        verbosity: 0
-
-    # ── Find backup circuit ───────────────────────────────────────────────────
+    # ── Find the active backup circuit ────────────────────────────────────────
 
     - name: Query dd-tagged circuits at A-side site
       ansible.builtin.set_fact:
@@ -134,7 +100,7 @@
                    validate_certs=netbox_validate_certs,
                    raw_data=true) }}
 
-    - name: Find circuits present at both sites (excluding the failed one)
+    - name: Find backup circuit (active, present at both sites, not the failed one)
       ansible.builtin.set_fact:
         z_circuit_ids: "{{ z_site_circuits | map(attribute='id') | list }}"
 
@@ -145,29 +111,36 @@
             a_site_circuits
             | selectattr('id', 'in', z_circuit_ids)
             | rejectattr('id', 'eq', primary.id)
+            | selectattr('status.value', 'eq', 'active')
             | list
           }}
 
-    - name: Fail if no backup found
-      ansible.builtin.assert:
-        that: backup_candidates | length > 0
-        fail_msg: >-
-          No active backup circuit found between
-          {{ a_side_site.display }} and {{ z_side_site.display }}
+    - name: Skip if no active backup found
+      when: backup_candidates | length == 0
+      block:
+        - name: No active backup — nothing to route to
+          ansible.builtin.debug:
+            msg: >-
+              No active backup circuit found between
+              {{ a_side_site.display }} and {{ z_side_site.display }}.
+              Skipping router config push.
+            verbosity: 0
 
-    - name: Select best backup (highest commit rate)
+        - name: Flag router config as skipped
+          ansible.builtin.set_stats:
+            data:
+              router_config_applied: false
+              router_config_error: >-
+                No active backup circuit found between
+                {{ a_side_site.display }} and {{ z_side_site.display }}
+            per_host: false
+
+        - name: End play — no backup to route to
+          ansible.builtin.meta: end_play
+
+    - name: Select backup (highest commit rate)
       ansible.builtin.set_fact:
         backup: "{{ backup_candidates | sort(attribute='commit_rate', reverse=true) | first }}"
-
-    - name: Show backup selection
-      ansible.builtin.debug:
-        msg: |
-          Found {{ backup_candidates | length }} backup candidate(s):
-          {% for c in backup_candidates | sort(attribute='commit_rate', reverse=true) %}
-            {{ '→' if c.id == backup.id else ' ' }} {{ c.cid }} ({{ c.provider.name }}, {{ c.commit_rate // 1000 }} Mbps)
-          {% endfor %}
-          Selected: {{ backup.cid }}
-        verbosity: 0
 
     # ── Query backup terminations ──────────────────────────────────────────────
 
@@ -181,12 +154,7 @@
                    validate_certs=netbox_validate_certs,
                    raw_data=true) }}
 
-    - name: Set backup site labels
-      ansible.builtin.set_fact:
-        backup_a_site: "{{ (backup_terms | selectattr('term_side', 'eq', 'A') | first).termination.display }}"
-        backup_z_site: "{{ (backup_terms | selectattr('term_side', 'eq', 'Z') | first).termination.display }}"
-
-    # ── Prepare termination data for per-router gateway derivation ──────
+    # ── Derive gateway IPs from cable wiring ──────────────────────────────────
 
     - name: Check if circuits have cable wiring
       ansible.builtin.set_fact:
@@ -194,7 +162,7 @@
           {{ (primary_terms | map(attribute='link_peers', default=[]) | select | list | length > 0)
              and (backup_terms | map(attribute='link_peers', default=[]) | select | list | length > 0) }}
 
-    - name: Query IPs for all cabled interfaces on failed circuit
+    - name: Query IPs for cabled interfaces on failed circuit
       ansible.builtin.set_fact:
         failed_term_ips: >-
           {{ failed_term_ips | default({}) | combine({
@@ -213,7 +181,7 @@
         - circuits_have_cables | bool
         - item.link_peers | default([]) | length > 0
 
-    - name: Query IPs for all cabled interfaces on backup circuit
+    - name: Query IPs for cabled interfaces on backup circuit
       ansible.builtin.set_fact:
         backup_term_ips: >-
           {{ backup_term_ips | default({}) | combine({
@@ -258,109 +226,116 @@
       ansible.builtin.set_fact:
         all_routers: "{{ a_side_routers + z_side_routers }}"
 
-    # ── Simulated router operations ──────────────────────────────────────────────
-    # Routers without a real IP in NetBox get simulated debug output here.
-    # Real router config push is handled by pb_router_config.yml (workflow step 2).
+    - name: Filter routers with real IPs
+      ansible.builtin.set_fact:
+        routers_with_ip: >-
+          {{
+            all_routers
+            | selectattr('primary_ip4', 'defined')
+            | selectattr('primary_ip4', 'ne', none)
+            | list
+          }}
 
-    - name: "[SIMULATED] Push failover config (no real router IP)"
-      ansible.builtin.debug:
-        msg: |
-          [SIMULATED] {{ item.name }}:
-            no ip route 0.0.0.0 0.0.0.0 {{ __sim_failed_gw }}
-            ip route 0.0.0.0 0.0.0.0 {{ __sim_backup_gw }}
-        verbosity: 0
-      vars:
-        __sim_failed_gw: >-
+    - name: Skip if no routers with real IPs
+      when: routers_with_ip | length == 0
+      block:
+        - name: No routers with IPs — skipping config push
+          ansible.builtin.debug:
+            msg: >-
+              No routers with primary_ip4 found at
+              {{ a_side_site.display }} or {{ z_side_site.display }}.
+              Router config push skipped (simulated routers only).
+            verbosity: 0
+
+        - name: Flag router config as skipped (no real routers)
+          ansible.builtin.set_stats:
+            data:
+              router_config_applied: false
+              router_config_error: "No routers with real IPs found — simulated routers only"
+            per_host: false
+
+        - name: End play — no real routers
+          ansible.builtin.meta: end_play
+
+    # ── Build dynamic inventory ───────────────────────────────────────────────
+
+    - name: Add routers with real IPs to dynamic inventory
+      ansible.builtin.add_host:
+        name: "{{ item.name }}"
+        groups: failover_routers
+        ansible_host: "{{ item.primary_ip4.address | ansible.utils.ipaddr('address') }}"
+        ansible_user: "{{ lookup('env', 'ROUTER_USERNAME') | default('iosuser', true) }}"
+        ansible_password: "{{ lookup('env', 'ROUTER_PASSWORD') | default(omit, true) }}"
+        ansible_network_os: cisco.ios.ios
+        ansible_connection: ansible.netcommon.network_cli
+        ansible_network_cli_ssh_type: paramiko
+        failed_gw: >-
           {{ (failed_term_ips[item.name][0].address
               | ansible.utils.ipaddr('network/prefix')
               | ansible.utils.nthhost(1))
              if (failed_term_ips is defined and item.name in failed_term_ips)
              else lookup('env', 'ROUTER_PRIMARY_GW') | default('172.16.0.1', true) }}
-        __sim_backup_gw: >-
+        backup_gw: >-
           {{ (backup_term_ips[item.name][0].address
               | ansible.utils.ipaddr('network/prefix')
               | ansible.utils.nthhost(1))
              if (backup_term_ips is defined and item.name in backup_term_ips)
              else lookup('env', 'ROUTER_BACKUP_GW') | default('172.16.1.1', true) }}
-      loop: >-
-        {{
-          all_routers
-          | rejectattr('primary_ip4', 'defined')
-          | list
-          +
-          all_routers
-          | selectattr('primary_ip4', 'defined')
-          | selectattr('primary_ip4', 'eq', none)
-          | list
-        }}
+      loop: "{{ routers_with_ip }}"
       loop_control:
         label: "{{ item.name }}"
 
-    # ── Update NetBox ─────────────────────────────────────────────────────────
-    # These are real writes — this is what updates the Visual Explorer map.
-
-    - name: Mark failed circuit as offline in NetBox
-      netbox.netbox.netbox_circuit:
-        netbox_url: "{{ netbox_url }}"
-        netbox_token: "{{ netbox_token }}"
-        validate_certs: "{{ netbox_validate_certs }}"
-        data:
-          cid: "{{ primary.cid }}"
-          status: "Offline"
-        state: present
-      register: primary_update
-      when: primary.status.value != 'offline'
-
-    - name: Confirm primary circuit updated
+    - name: Show router targets
       ansible.builtin.debug:
         msg: >-
-          {{ primary.cid }}:
-          {{ primary.status.label }} → offline
-          (update skipped — already offline)
+          Pushing failover config to {{ routers_with_ip | length }} router(s):
+          {{ routers_with_ip | map(attribute='name') | join(', ') }}
         verbosity: 0
-      when: primary.status.value == 'offline'
 
-    - name: Confirm primary circuit updated (was changed)
-      ansible.builtin.debug:
-        msg: >-
-          {{ primary.cid }}:
-          {{ primary.status.label }} → {{ primary_update.circuit.status }}
-        verbosity: 0
-      when: primary.status.value != 'offline'
+# ── Play 2: Push failover routing to real routers ─────────────────────────────
 
-    - name: Set backup circuit to active in NetBox
-      netbox.netbox.netbox_circuit:
-        netbox_url: "{{ netbox_url }}"
-        netbox_token: "{{ netbox_token }}"
-        validate_certs: "{{ netbox_validate_certs }}"
-        data:
-          cid: "{{ backup.cid }}"
-          status: "Active"
-        state: present
-      register: backup_update
-      when: backup.status.value != 'active'
+- name: "Apply failover routing — {{ failed_circuit | default('unknown') }}"
+  hosts: failover_routers
+  gather_facts: false
+  ignore_unreachable: true
 
-    - name: Confirm backup circuit active (no change needed)
-      ansible.builtin.debug:
-        msg: >-
-          {{ backup.cid }}: already active — no update needed
-        verbosity: 0
-      when: backup.status.value == 'active'
+  tasks:
+    - name: Push failover routing config
+      block:
+        - name: Remove failed route and add backup route
+          cisco.ios.ios_config:
+            lines:
+              - "no ip route 0.0.0.0 0.0.0.0 {{ failed_gw }}"
+              - "ip route 0.0.0.0 0.0.0.0 {{ backup_gw }}"
+            save_when: changed
 
-    - name: Confirm backup circuit active (was changed)
-      ansible.builtin.debug:
-        msg: >-
-          {{ backup.cid }}:
-          {{ backup.status.label }} → {{ backup_update.circuit.status }}
-        verbosity: 0
-      when: backup.status.value != 'active'
+        - name: Router failover config applied
+          ansible.builtin.debug:
+            msg: >-
+              {{ inventory_hostname }}: failed route ({{ failed_gw }})
+              removed, backup route ({{ backup_gw }}) added
+            verbosity: 0
 
-    - name: Failover complete
-      ansible.builtin.debug:
-        msg: |
-          Failover complete for {{ failed_circuit }}
-            Primary:  {{ primary.cid }} -> Offline
-            Backup:   {{ backup.cid }} ({{ backup.provider.name }}, {{ backup.commit_rate // 1000 }} Mbps)
-            Routers:  {{ all_routers | map(attribute='name') | join(', ') }}
-          Next workflow steps: router config push, then report generation.
-        verbosity: 0
+        - name: Flag router config as applied
+          ansible.builtin.set_stats:
+            data:
+              router_config_applied: true
+            per_host: false
+
+      rescue:
+        - name: Router config push failed (non-fatal)
+          ansible.builtin.debug:
+            msg: >-
+              WARNING: Could not push config to {{ inventory_hostname }}.
+              Error: {{ ansible_failed_result.msg | default('unknown') }}.
+              Workflow continues to Deploy Report step.
+            verbosity: 0
+
+        - name: Flag router config as failed
+          ansible.builtin.set_stats:
+            data:
+              router_config_applied: false
+              router_config_error: >-
+                Config push failed on {{ inventory_hostname }}:
+                {{ ansible_failed_result.msg | default('unknown') }}
+            per_host: false

--- a/ansible/pb_router_config.yml
+++ b/ansible/pb_router_config.yml
@@ -60,9 +60,11 @@
         ansible_host: "{{ item.ip }}"
         ansible_user: "{{ lookup('env', 'ROUTER_USERNAME') | default('iosuser', true) }}"
         ansible_password: "{{ lookup('env', 'ROUTER_PASSWORD') | default(omit, true) }}"
+        ansible_ssh_private_key_file: "{{ lookup('env', 'PRIVATE_KEY_PATH') | default(omit, true) }}"
         ansible_network_os: cisco.ios.ios
         ansible_connection: ansible.netcommon.network_cli
-        ansible_network_cli_ssh_type: paramiko
+        ansible_network_cli_ssh_type: libssh
+        ansible_host_key_checking: false
         failed_gw: "{{ item.failed_gw }}"
         backup_gw: "{{ item.backup_gw }}"
       loop: "{{ router_targets }}"

--- a/ansible/pb_router_config.yml
+++ b/ansible/pb_router_config.yml
@@ -79,6 +79,9 @@
         verbosity: 0
 
 # ── Play 2: Push failover routing to real routers ─────────────────────────────
+# NOTE: set_stats with per_host: false means last host wins. With a single
+# demo router this is fine; for multiple routers, add a Play 3 on localhost
+# to aggregate per-host results before calling set_stats.
 
 - name: "Apply failover routing — {{ failed_circuit | default('unknown') }}"
   hosts: failover_routers

--- a/ansible/pb_setup_aap.yml
+++ b/ansible/pb_setup_aap.yml
@@ -341,10 +341,9 @@
         execution_environment: "{{ ee_legacy_name }}"
         job_type: run
         ask_variables_on_launch: true
-        credentials:
-          - "{{ netbox_cred_name }}"
         description: >-
           Step 2: Push failover routing config to real routers.
+          Receives router targets via set_stats from failover step.
           Uses legacy-crypto EE for IOS-XE < 17 (SHA-1 SSH).
         state: present
       tags:
@@ -834,7 +833,6 @@
             organization: "{{ aap_org_name }}"
             execution_environment: "{{ ee_legacy_name }}"
             credentials:
-              - "{{ netbox_cred_name }}"
               - "{{ router_cred_name }}"
             state: present
 

--- a/ansible/pb_setup_aap.yml
+++ b/ansible/pb_setup_aap.yml
@@ -11,10 +11,12 @@
 #     - NetBox credential (Summit Demo)
 #     - Localhost inventory + host
 #     - GitHub project
+#     - Execution Environment (standard + legacy-crypto)
 #     - Job template: Circuit Failover
+#     - Job template: Push Router Config
 #     - Job template: Deploy Report
 #     - Job template: Reset Demo
-#     - Workflow template: Circuit Failover Workflow (Failover → Report)
+#     - Workflow: Circuit Failover (Failover → Router Config → Report)
 #
 #   EDA:
 #     - Decision environment (or reuse existing)
@@ -80,7 +82,7 @@
     ee_name: "{{ aap_org_name }} Execution Environment"
     ee_image: "quay.io/acme_corp/netbox-summit-2026-ee:v3.22-3"
     ee_legacy_name: "{{ aap_org_name }} Legacy Crypto EE"
-    ee_legacy_image: "quay.io/acme_corp/netbox-summit-2026-ee-legacy-crypto:latest"
+    ee_legacy_image: "quay.io/acme_corp/netbox-webinar-legacy-crypto-ee:latest"
     registry_cred_name: "{{ aap_org_name }} Container Registry"
     rh_registry_cred_name: "{{ aap_org_name }} Red Hat Registry"
     galaxy_cred_name: "{{ aap_org_name }} Automation Hub"

--- a/ansible/pb_setup_aap.yml
+++ b/ansible/pb_setup_aap.yml
@@ -47,7 +47,7 @@
     - vars/netbox_creds.yml
 
   vars:
-    aap_org_name: "SummitCollection"
+    aap_org_name: "Webinar"
     controller_api_base: "{{ lookup('env', 'AAP_URL') }}/api/controller"
     github_repo: "https://github.com/leogallego/summit-netbox-circuits-demo"
     github_branch: "main"

--- a/ansible/pb_setup_aap.yml
+++ b/ansible/pb_setup_aap.yml
@@ -65,6 +65,7 @@
     inventory_name: "{{ aap_org_name }} Localhost"
     controller_project_name: "{{ aap_org_name }} NetBox Circuits Demo"
     jt_failover_name: "{{ aap_org_name }} Circuit Failover"
+    jt_router_config_name: "{{ aap_org_name }} Push Router Config"
     jt_report_name: "{{ aap_org_name }} Deploy Report"
     jt_reset_name: "{{ aap_org_name }} Reset Demo"
     workflow_name: "{{ aap_org_name }} Circuit Failover Workflow"
@@ -75,9 +76,11 @@
     router_device_role: "router"
     router_device_site: "us-atlanta"
     router_mgmt_iface_name: "GigabitEthernet1"
-    # Execution Environment
+    # Execution Environments
     ee_name: "{{ aap_org_name }} Execution Environment"
     ee_image: "quay.io/acme_corp/netbox-summit-2026-ee:v3.22-3"
+    ee_legacy_name: "{{ aap_org_name }} Legacy Crypto EE"
+    ee_legacy_image: "quay.io/acme_corp/netbox-summit-2026-ee-legacy-crypto:latest"
     registry_cred_name: "{{ aap_org_name }} Container Registry"
     rh_registry_cred_name: "{{ aap_org_name }} Red Hat Registry"
     galaxy_cred_name: "{{ aap_org_name }} Automation Hub"
@@ -292,6 +295,19 @@
       tags:
         - ee
 
+    - name: Create legacy-crypto execution environment
+      ansible.controller.execution_environment:
+        name: "{{ ee_legacy_name }}"
+        image: "{{ ee_legacy_image }}"
+        organization: "{{ aap_org_name }}"
+        credential: "{{ registry_cred_name if lookup('env', 'REGISTRY_USERNAME') | length > 0 else omit }}"
+        description: >-
+          EE with SHA-1 crypto policy overrides for IOS-XE < 17 routers.
+        pull: missing
+        state: present
+      tags:
+        - ee
+
     # ── Controller: Job Template — Circuit Failover ───────────────────────────
 
     - name: Create Circuit Failover job template
@@ -307,8 +323,29 @@
         credentials:
           - "{{ netbox_cred_name }}"
         description: >-
-          Automated circuit failover driven by NetBox SoT.
+          Step 1: Query NetBox, discover backup circuit, update SoT.
           Pass failed_circuit as extra var.
+        state: present
+      tags:
+        - job_templates
+
+    # ── Controller: Job Template — Push Router Config ────────────────────────
+
+    - name: Create Push Router Config job template
+      ansible.controller.job_template:
+        name: "{{ jt_router_config_name }}"
+        organization: "{{ aap_org_name }}"
+        inventory: "{{ inventory_name }}"
+        project: "{{ controller_project_name }}"
+        playbook: "ansible/pb_router_config.yml"
+        execution_environment: "{{ ee_legacy_name }}"
+        job_type: run
+        ask_variables_on_launch: true
+        credentials:
+          - "{{ netbox_cred_name }}"
+        description: >-
+          Step 2: Push failover routing config to real routers.
+          Uses legacy-crypto EE for IOS-XE < 17 (SHA-1 SSH).
         state: present
       tags:
         - job_templates
@@ -364,8 +401,8 @@
         name: "{{ workflow_name }}"
         organization: "{{ aap_org_name }}"
         description: >-
-          Automated WAN circuit failover: updates NetBox
-          and deploys the incident report.
+          Automated WAN circuit failover: (1) update NetBox SoT,
+          (2) push router config, (3) generate incident report.
         ask_variables_on_launch: true
         workflow_nodes:
           - identifier: failover
@@ -376,6 +413,15 @@
               type: job_template
             related:
               success_nodes:
+                - identifier: router_config
+          - identifier: router_config
+            unified_job_template:
+              name: "{{ jt_router_config_name }}"
+              organization:
+                name: "{{ aap_org_name }}"
+              type: job_template
+            related:
+              always_nodes:
                 - identifier: report
           - identifier: report
             unified_job_template:
@@ -782,28 +828,15 @@
                 address: "{{ router_ip }}/32"
             state: present
 
-        - name: Attach Network credential to Circuit Failover template
+        - name: Attach Network credential to Push Router Config template
           ansible.controller.job_template:
-            name: "{{ jt_failover_name }}"
+            name: "{{ jt_router_config_name }}"
             organization: "{{ aap_org_name }}"
-            execution_environment: "{{ ee_name }}"
-            credentials:
-              - "{{ netbox_cred_name }}"
-              - "{{ report_server_cred_name }}"
-              - "{{ router_cred_name }}"
-            state: present
-          when: report_server_host | length > 0
-
-        - name: Attach Network credential to Circuit Failover template (no report server)
-          ansible.controller.job_template:
-            name: "{{ jt_failover_name }}"
-            organization: "{{ aap_org_name }}"
-            execution_environment: "{{ ee_name }}"
+            execution_environment: "{{ ee_legacy_name }}"
             credentials:
               - "{{ netbox_cred_name }}"
               - "{{ router_cred_name }}"
             state: present
-          when: report_server_host | length == 0
 
         - name: Attach Network credential to Reset Demo template
           ansible.controller.job_template:

--- a/ansible/templates/failover_report.html.j2
+++ b/ansible/templates/failover_report.html.j2
@@ -255,6 +255,7 @@
          ({{ backup.commit_rate // 1000 }} Mbps — highest available capacity).</p>
     </div>
 
+{% if router_config_applied | default(true) | bool %}
     <div class="step push">
       <h3>Router configuration updated <span class="ts">T+8.3s</span></h3>
       <p>Ansible Automation Platform pushed failover routing to <strong>{{ routers | length }}</strong> router(s)
@@ -268,6 +269,17 @@
   end</div>
 {% endfor %}
     </div>
+{% else %}
+    <div class="step push" style="border-left-color: #f59e0b;">
+      <h3><span class="badge warning">WARNING</span> Router configuration was NOT applied <span class="ts">T+8.3s</span></h3>
+      <p>The router config push step did not complete successfully.
+{% if router_config_error | default('') | length > 0 %}
+         Reason: <strong>{{ router_config_error }}</strong>.
+{% endif %}
+         NetBox SoT has been updated but router routing tables may still point to the failed circuit.
+         <strong>Manual intervention may be required.</strong></p>
+    </div>
+{% endif %}
 
     <div class="step update">
       <h3>NetBox Source of Truth updated <span class="ts">T+21.6s</span></h3>


### PR DESCRIPTION
## Summary

- Split router config push from `pb_circuit_failover.yml` into `pb_router_config.yml` so it can run on the legacy-crypto EE (`ee-supported-rhel9:1.0` base with SHA-1 crypto overrides) for IOS-XE < 17 routers
- Router config playbook receives targets via `set_stats` artifacts from the failover step — no `netbox.netbox` dependency, runs on the minimal legacy EE
- Updated `pb_setup_aap.yml`: legacy-crypto EE registration, new job template, 3-step workflow (failover → router config → report)
- Tested against CSR 1000v 16.12 on AWS with the legacy-crypto EE

## Changes

| File | Change |
|------|--------|
| `ansible/pb_router_config.yml` | New playbook: accepts `router_targets` from `set_stats`, builds dynamic inventory, pushes `cisco.ios.ios_config` |
| `ansible/pb_circuit_failover.yml` | Added `set_stats` to pass router targets (name, IP, gateway pairs) to next workflow step |
| `ansible/pb_setup_aap.yml` | Added legacy-crypto EE, new JT, 3-step workflow, removed NetBox credential from router config JT |

## Workflow

```
failover (standard EE) →(success)→ router_config (legacy-crypto EE) →(always)→ report (standard EE)
```

- If failover fails, nothing else runs
- If router config fails, report still runs with a warning banner
- `set_stats` passes `router_config_applied` (bool) and `router_config_error` to report step

## Test plan

- [x] `ansible-lint` passes at production profile
- [x] Failover playbook exits cleanly when circuit is not offline
- [x] Router config playbook skips gracefully with empty `router_targets`
- [x] Router config playbook pushes config to CSR 1000v 16.12 via legacy-crypto EE
- [ ] Full workflow test on AAP (failover → router config → report)
- [ ] Push updated legacy-crypto EE to quay

Closes #49

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>