### PR TITLE
feat: add NetBox MCP server to MCP setup playbook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,8 @@ ROUTER_BACKUP_GW=172.16.1.1
 MCP_AAP_TOKEN=
 MCP_AAP_SERVER=
 MCP_AAP_PORT=8448
+# Read-only NetBox API token for MCP server (separate from NETBOX_TOKEN)
+MCP_NETBOX_TOKEN=
 # Container runtime for NetBox MCP server (podman or docker)
 MCP_CONTAINER_RUNTIME=podman
 # Set to false only for self-signed certs in dev/demo environments

--- a/.env.example
+++ b/.env.example
@@ -54,4 +54,7 @@ ROUTER_BACKUP_GW=172.16.1.1
 MCP_AAP_TOKEN=
 MCP_AAP_SERVER=
 MCP_AAP_PORT=8448
-MCP_NETBOX_TOKEN=
+# Container runtime for NetBox MCP server (podman or docker)
+MCP_CONTAINER_RUNTIME=podman
+# Set to false only for self-signed certs in dev/demo environments
+NETBOX_VERIFY_SSL=true

--- a/ansible/pb_setup_mcp.yml
+++ b/ansible/pb_setup_mcp.yml
@@ -1,12 +1,21 @@
 ---
 # pb_setup_mcp.yml
 #
-# Generates .mcp.json for AI MCP integration with AAP.
-# Reads AAP gateway host from env vars and templates the config locally.
+# Generates .mcp.json for AI MCP integration with AAP and NetBox.
+# Pulls the NetBox MCP server container image and templates the config locally.
 #
 # Usage:
 #   source .env
 #   ./run-playbook.sh ansible/pb_setup_mcp.yml
+#
+# Tags:
+#   netbox  — pull NetBox MCP server container image
+#   config  — generate .mcp.json only (no image pull)
+#
+# Examples:
+#   ./run-playbook.sh ansible/pb_setup_mcp.yml                  # full setup
+#   ./run-playbook.sh ansible/pb_setup_mcp.yml --tags config    # regenerate config only
+#   ./run-playbook.sh ansible/pb_setup_mcp.yml --tags netbox    # pull image only
 
 - name: Generate MCP configuration
   hosts: localhost
@@ -14,11 +23,16 @@
   gather_facts: false
 
   vars:
+    container_runtime: "{{ lookup('env', 'MCP_CONTAINER_RUNTIME') | default('podman', true) }}"
     mcp_aap_host: >-
       {{ lookup('env', 'MCP_AAP_SERVER') |
          default(lookup('env', 'AAP_URL') | urlsplit('hostname'), true) }}
     mcp_aap_port: "{{ lookup('env', 'MCP_AAP_PORT') | default('8448', true) }}"
     mcp_aap_base_url: "https://{{ mcp_aap_host }}:{{ mcp_aap_port }}"
+    netbox_url: "{{ lookup('env', 'NETBOX_URL') }}"
+    netbox_token: "{{ lookup('env', 'NETBOX_TOKEN') }}"
+    netbox_verify_ssl: "{{ lookup('env', 'NETBOX_VERIFY_SSL') | default('true', true) | bool }}"
+    netbox_mcp_image: "netboxlabs/netbox-mcp-server:1.2.0"
     mcp_services:
       - name: aap-mcp-job-management
         path: job_management
@@ -42,17 +56,32 @@
         fail_msg: >-
           Cannot determine AAP gateway host. Set AAP_URL or MCP_AAP_SERVER
           in your .env file.
+      tags:
+        - always
+
+    - name: Pull NetBox MCP server image
+      ansible.builtin.command:
+        cmd: "{{ container_runtime }} pull {{ netbox_mcp_image }}"
+      register: netbox_mcp_pull
+      changed_when: "'Pulling' in netbox_mcp_pull.stdout or 'Downloading' in netbox_mcp_pull.stdout"
+      tags:
+        - netbox
 
     - name: Generate .mcp.json
       ansible.builtin.template:
         src: "{{ playbook_dir }}/templates/mcp.json.j2"
         dest: "{{ playbook_dir }}/../.mcp.json"
         mode: "0600"
+      tags:
+        - config
 
     - name: MCP configuration generated
       ansible.builtin.debug:
         msg: >-
           .mcp.json written — {{ mcp_services | length }} AAP MCP services
-          pointing at {{ mcp_aap_base_url }}.
+          pointing at {{ mcp_aap_base_url }}, plus NetBox
+          ({{ netbox_mcp_image }} via {{ container_runtime }}).
           Set MCP_AAP_TOKEN in your .env to authenticate.
         verbosity: 0
+      tags:
+        - config

--- a/ansible/pb_setup_mcp.yml
+++ b/ansible/pb_setup_mcp.yml
@@ -29,8 +29,9 @@
          default(lookup('env', 'AAP_URL') | urlsplit('hostname'), true) }}
     mcp_aap_port: "{{ lookup('env', 'MCP_AAP_PORT') | default('8448', true) }}"
     mcp_aap_base_url: "https://{{ mcp_aap_host }}:{{ mcp_aap_port }}"
+    mcp_netbox_token: "{{ lookup('env', 'MCP_NETBOX_TOKEN') }}"
+    mcp_netbox_enabled: "{{ mcp_netbox_token | length > 0 }}"
     netbox_url: "{{ lookup('env', 'NETBOX_URL') }}"
-    netbox_token: "{{ lookup('env', 'NETBOX_TOKEN') }}"
     netbox_verify_ssl: "{{ lookup('env', 'NETBOX_VERIFY_SSL') | default('true', true) | bool }}"
     netbox_mcp_image: "netboxlabs/netbox-mcp-server:1.2.0"
     mcp_services:
@@ -64,6 +65,7 @@
         cmd: "{{ container_runtime }} pull {{ netbox_mcp_image }}"
       register: netbox_mcp_pull
       changed_when: "'Pulling' in netbox_mcp_pull.stdout or 'Downloading' in netbox_mcp_pull.stdout"
+      when: mcp_netbox_enabled
       tags:
         - netbox
 
@@ -79,8 +81,7 @@
       ansible.builtin.debug:
         msg: >-
           .mcp.json written — {{ mcp_services | length }} AAP MCP services
-          pointing at {{ mcp_aap_base_url }}, plus NetBox
-          ({{ netbox_mcp_image }} via {{ container_runtime }}).
+          pointing at {{ mcp_aap_base_url }}{{ ', plus NetBox (' ~ netbox_mcp_image ~ ' via ' ~ container_runtime ~ ')' if mcp_netbox_enabled else ' (NetBox MCP skipped — MCP_NETBOX_TOKEN not set)' }}.
           Set MCP_AAP_TOKEN in your .env to authenticate.
         verbosity: 0
       tags:

--- a/ansible/templates/mcp.json.j2
+++ b/ansible/templates/mcp.json.j2
@@ -6,7 +6,23 @@
       "type": "http",
       "url": "{{ mcp_aap_base_url }}/{{ service.path }}/mcp",
       "headersHelper": "echo '{\"Authorization\": \"Bearer '\"$MCP_AAP_TOKEN\"'\"}'"
-    }{{ "," if not loop.last else "" }}
+    },
 {% endfor %}
+    "netbox": {
+      "command": "{{ container_runtime }}",
+      "args": [
+        "run", "--rm", "-i",
+        "-e", "NETBOX_URL",
+        "-e", "NETBOX_TOKEN",
+{% if not netbox_verify_ssl %}
+        "-e", "VERIFY_SSL=false",
+{% endif %}
+        "{{ netbox_mcp_image }}"
+      ],
+      "env": {
+        "NETBOX_URL": "{{ netbox_url }}",
+        "NETBOX_TOKEN": "{{ netbox_token }}"
+      }
+    }
   }
 }

--- a/ansible/templates/mcp.json.j2
+++ b/ansible/templates/mcp.json.j2
@@ -6,8 +6,9 @@
       "type": "http",
       "url": "{{ mcp_aap_base_url }}/{{ service.path }}/mcp",
       "headersHelper": "echo '{\"Authorization\": \"Bearer '\"$MCP_AAP_TOKEN\"'\"}'"
-    },
+    }{{ "," if not loop.last or mcp_netbox_enabled else "" }}
 {% endfor %}
+{% if mcp_netbox_enabled %}
     "netbox": {
       "command": "{{ container_runtime }}",
       "args": [
@@ -21,8 +22,9 @@
       ],
       "env": {
         "NETBOX_URL": "{{ netbox_url }}",
-        "NETBOX_TOKEN": "{{ netbox_token }}"
+        "NETBOX_TOKEN": "{{ mcp_netbox_token }}"
       }
     }
+{% endif %}
   }
 }


### PR DESCRIPTION
## Summary
- Adds containerized NetBox MCP server (`netboxlabs/netbox-mcp-server:1.2.0`) to `pb_setup_mcp.yml`
- Pre-pulls the container image during setup so it's ready at demo time
- Configurable container runtime via `MCP_CONTAINER_RUNTIME` (defaults to `podman`)
- SSL verification sourced from `NETBOX_VERIFY_SSL` env var (defaults to `true`)
- Proper tag structure: `--tags config` for config-only, `--tags netbox` for image pull only

## Test plan
- [ ] Run `./run-playbook.sh ansible/pb_setup_mcp.yml` — verify image pull + `.mcp.json` generated
- [ ] Run `./run-playbook.sh ansible/pb_setup_mcp.yml --tags config` — verify no image pull
- [ ] Verify generated `.mcp.json` contains both AAP and NetBox server entries
- [ ] Verify NetBox MCP server connects successfully via the generated config

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>